### PR TITLE
Use correct function in notifications workflow

### DIFF
--- a/.github/workflows/misc-send-notification-on-workflow-errors.yml
+++ b/.github/workflows/misc-send-notification-on-workflow-errors.yml
@@ -28,13 +28,13 @@ jobs:
         with:
           repository: felleslosninger/github-workflows
           path: tools
-      - name: Use JS Tools
+      - name: Get commit message
         id: commit-message
         uses: actions/github-script@v6
         with:
           script: |
             const Utils = require('./tools/.github/js/github-context-utils.js');
-            const message = Utils.getHeadCommitMessage(${{ toJson(github) }});
+            const message = Utils.getCommitMessage(${{ toJson(github) }});
             return message;
       - name: Notify
         if: ${{ matrix.channel != '' }}


### PR DESCRIPTION
Fix notification GH workflow to use exported function (same as what was done in **eid-github-workflows** repo).