### PR TITLE
PF-1102 Add continue-on-error

### DIFF
--- a/.github/workflows/ci-check-for-cve-suppression-changes.yml
+++ b/.github/workflows/ci-check-for-cve-suppression-changes.yml
@@ -9,6 +9,9 @@ name: Check for CVE suppression changes
 on:
   workflow_call:
 jobs:
+
+  continue-on-error: true
+
   check-for-cve-suppression-changes:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Vi må fortsette workflowen selv om en av de feiler. Dette gjelder en resuasble workflow `check-for-cve-suppression-changes ` som feiler når en commit hash er: 0000000000000000000000000000000000000000

