### PR TITLE
Revert "Bump aquasecurity/trivy-action from 0.16.1 to 0.18.0 (#62)"

### DIFF
--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -99,7 +99,7 @@ jobs:
             --env BP_MAVEN_POM_FILE="./pom.xml" \
             --creation-time now
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@v0.18.0
+        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # pin@v0.16.1
         with:
           image-ref: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
           exit-code: "1"

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -90,7 +90,7 @@ jobs:
             image: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
             artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
         - name: Run Trivy vulnerability scanner
-          uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@v0.18.0
+          uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # pin@v0.16.1
           with:
             image-ref: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
             exit-code: '1'

--- a/.github/workflows/ci-quarkus-native-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-native-build-publish-image.yml
@@ -100,7 +100,7 @@ jobs:
             --env BP_NATIVE_IMAGE="true" \
             --creation-time now
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@v0.18.0
+        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # pin@v0.16.1
         with:
           image-ref: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
           exit-code: "1"

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Build image with Maven/Spring Boot
         run: mvn -B spring-boot:build-image --file pom.xml -Dspring-boot.build-image.imageName=${{env.IMAGE-NAME}}:${{env.IMAGETAG}} -Dspring-boot.build-image.builder=paketobuildpacks/${{ inputs.image-pack }} -Dspring-boot.build-image.createdDate=now
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@v0.18.0
+        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # pin@v0.16.1
         with:
           image-ref: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
           exit-code: "1"

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -78,7 +78,7 @@ jobs:
             image: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
             artifact-name: sbom-${{steps.sbom-name.outputs.SBOM_ARTIFACT_ID}}-${{env.IMAGETAG}}.spdx
         - name: Run Trivy vulnerability scanner
-          uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@v0.18.0
+          uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # pin@v0.16.1
           with:
             image-ref: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
             exit-code: '1'

--- a/.github/workflows/test-k6-build-docker.yml
+++ b/.github/workflows/test-k6-build-docker.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build the tagged Docker image
         run: docker build --tag ${{env.IMAGE-NAME}}:${{env.IMAGETAG}} docker/
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@v0.18.0
+        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # pin@v0.16.1
         with:
           image-ref: ${{env.IMAGE-NAME}}:${{env.IMAGETAG}}
           exit-code: '1'

--- a/.github/workflows/test-k6-build-publish-docker.yml
+++ b/.github/workflows/test-k6-build-publish-docker.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build the tagged Docker image
         run: docker build --tag ${{env.IMAGE_NAME}}:${{env.IMAGETAG}} docker/
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # pin@v0.18.0
+        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # pin@v0.16.1
         with:
           image-ref: ${{env.IMAGE_NAME}}:${{env.IMAGETAG}}
           exit-code: "1"


### PR DESCRIPTION
This reverts commit 6b6075da531ae6b8e089d9bb8c1faff7ff07232d since it reports false positives of CVE on older versions that does not exist in our image!

Also created issue at trivy-action of this problem: https://github.com/aquasecurity/trivy-action/issues/319