### PR TITLE
PF-1402 Adding slsaprovenance as --type when pushing to ACR

### DIFF
--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -187,7 +187,7 @@ jobs:
         if: ${{ inputs.image-signing == true }}
         run: |
           cosign sign --yes "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
-          cosign attest --yes --predicate ./provenance.json "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
+          cosign attest --yes --predicate ./provenance.json --type slsaprovenance "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
         env:
           DIGEST: ${{ steps.set-image-digest.outputs.image-digest }}
 

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -227,7 +227,7 @@ jobs:
         if: ${{ inputs.image-signing == true }}
         run: |
           cosign sign --yes "${{ env.IMAGE-NAME }}@${DIGEST}"
-          cosign attest --yes --predicate ./provenance.json "${{ env.IMAGE-NAME }}@${DIGEST}"
+          cosign attest --yes --predicate ./provenance.json --type slsaprovenance "${{ env.IMAGE-NAME }}@${DIGEST}"
         env:
           DIGEST: ${{ env.IMAGE_DIGEST }}
 

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -277,7 +277,7 @@ jobs:
         if: ${{ inputs.image-signing == true }}
         run: |
           cosign sign --yes "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
-          cosign attest --yes --predicate ./provenance.json "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
+          cosign attest --yes --predicate ./provenance.json --type slsaprovenance "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
         env:
           DIGEST: ${{ steps.set-image-digest.outputs.image-digest }}
 


### PR DESCRIPTION
Our push command for attestations was missing the `--type slsaprovenance` parameter. Causing verification on the provenance metadata to fail