### PR TITLE
PF-1408 slsaprovenance was not good enough must use slsaprovenance1 as type

### DIFF
--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -228,7 +228,7 @@ jobs:
         if: ${{ inputs.image-signing == true }}
         run: |
           cosign sign --yes "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
-          cosign attest --yes --predicate ./provenance.json --type slsaprovenance "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
+          cosign attest --yes --predicate ./provenance.json --type slsaprovenance1 "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
         env:
           DIGEST: ${{ steps.set-image-digest.outputs.image-digest }}
 

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -268,7 +268,7 @@ jobs:
         if: ${{ inputs.image-signing == true }}
         run: |
           cosign sign --yes "${{ env.IMAGE-NAME }}@${DIGEST}"
-          cosign attest --yes --predicate ./provenance.json --type slsaprovenance "${{ env.IMAGE-NAME }}@${DIGEST}"
+          cosign attest --yes --predicate ./provenance.json --type slsaprovenance1 "${{ env.IMAGE-NAME }}@${DIGEST}"
         env:
           DIGEST: ${{ env.IMAGE_DIGEST }}
 

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -318,7 +318,7 @@ jobs:
         if: ${{ inputs.image-signing == true }}
         run: |
           cosign sign --yes "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
-          cosign attest --yes --predicate ./provenance.json --type slsaprovenance "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
+          cosign attest --yes --predicate ./provenance.json --type slsaprovenance1 "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
         env:
           DIGEST: ${{ steps.set-image-digest.outputs.image-digest }}
 


### PR DESCRIPTION
When signing the image we also add the slsa provenance data like this:

`cosign attest --yes --predicate ./provenance.json --type slsaprovenance "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"
`
But when we are _verifying_, with kyverno, we expects the slsa provenance data to be compliant with slsa provenance v1. 

We must explicitly use the slsaprovenance1 when defining the type:

```
 --type='custom':     
specify a predicate type     

(slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI

```
The correct cosign command should be:

`cosign attest --yes --predicate ./provenance.json --type slsaprovenance1 "${{ steps.set-image-name.outputs.image-name }}@${DIGEST}"`