### PR TITLE
PF-1452 Check for CVE fails with Invalid revision range

### DIFF
--- a/.github/workflows/ci-check-for-cve-suppression-changes.yml
+++ b/.github/workflows/ci-check-for-cve-suppression-changes.yml
@@ -22,12 +22,39 @@ jobs:
           npm install @influxdata/influxdb-client
           npm install @actions/core
 
+      - name: Determine Commit Hashes
+        id: commit-hashes
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Handle pull request event
+            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" || "${{ github.event.after }}" == "0000000000000000000000000000000000000000" ]]; then
+              echo "Using PR head commit for diff"
+              COMMIT_HASH_BEFORE=$(git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD)
+              COMMIT_HASH_AFTER=${{ github.event.pull_request.head.sha }}
+            else
+              COMMIT_HASH_BEFORE=${{ github.event.before }}
+              COMMIT_HASH_AFTER=${{ github.event.after }}
+            fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            # Handle push event
+            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
+              echo "Fetching previous commit"
+              COMMIT_HASH_BEFORE=$(git rev-parse HEAD^)
+              COMMIT_HASH_AFTER=$(git rev-parse HEAD)
+            else
+              COMMIT_HASH_BEFORE=${{ github.event.before }}
+              COMMIT_HASH_AFTER=${{ github.event.after }}
+            fi
+          else
+            echo "Unsupported event type"
+            exit 1
+          fi
+          echo "COMMIT_HASH_BEFORE=$COMMIT_HASH_BEFORE" >> $GITHUB_ENV
+          echo "COMMIT_HASH_AFTER=$COMMIT_HASH_AFTER" >> $GITHUB_ENV
+
       - name: Check for CVE suppression changes in trivyignore
         id: new-cve-suppressions
         if: ${{ hashFiles('./.trivyignore') != '' }}
-        env:
-          COMMIT_HASH_BEFORE: ${{ github.event.before }}
-          COMMIT_HASH_AFTER: ${{ github.event.after }}
         run: |
           # File with CVEs
           TRIVYIGNORE_FILE=.trivyignore

--- a/.github/workflows/ci-check-for-cve-suppression-changes.yml
+++ b/.github/workflows/ci-check-for-cve-suppression-changes.yml
@@ -29,11 +29,11 @@ jobs:
             # Handle pull request event
             if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" || "${{ github.event.after }}" == "0000000000000000000000000000000000000000" ]]; then
               echo "Using PR head commit for diff"
-              COMMIT_HASH_BEFORE=$(git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD)
-              COMMIT_HASH_AFTER=${{ github.event.pull_request.head.sha }}
+              COMMIT_HASH_BEFORE=$(git merge-base origin/"${{ github.event.pull_request.base.ref }}" HEAD)
+              COMMIT_HASH_AFTER="${{ github.event.pull_request.head.sha }}"
             else
-              COMMIT_HASH_BEFORE=${{ github.event.before }}
-              COMMIT_HASH_AFTER=${{ github.event.after }}
+              COMMIT_HASH_BEFORE="${{ github.event.before }}"
+              COMMIT_HASH_AFTER="${{ github.event.after }}"
             fi
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             # Handle push event


### PR DESCRIPTION
This happens when something unusual has happened in a app repo, from a push or pull-request command

Needs a more fault tolerant behaviour

```
Run # File with CVEs
  # File with CVEs
  TRIVYIGNORE_FILE=.trivyignore
  
  # File with git diff results
  GIT_DIFF_RAW_FILE=trivy-git-diff.txt
  
  # CVE format pattern: CVE-[0-9]{4}-[0-9]{1,}
  # With expected leading prefix: '+' for added and '-' for removed
  regex_pattern="^([+]|[-])(CVE|cve)-[0-9]{4}-[0-9]{1,}$"
  
  git diff --ignore-all-space 0000000000000000000000000000000000000000..ce538[2](https://github.com/felleslosninger/efm-move-admin/actions/runs/11372468579/job/31637347188#step:4:2)0ae585c9f319af72cb9ae[3](https://github.com/felleslosninger/efm-move-admin/actions/runs/11372468579/job/31637347188#step:4:3)c20e49b45f22 -- $TRIVYIGNORE_FILE > $GIT_DIFF_RAW_FILE
  
  suppressions_with_delimiter=""
  while read -r diff_string
  do
    suppression=$(cut -d' ' -f 1 <<< "$diff_string")
    if [[ $suppression =~ $regex_pattern ]]; then
      suppressions_with_delimiter+="$suppression,"
    fi
  done < <(grep '' $GIT_DIFF_RAW_FILE)
  echo "suppressions=$suppressions_with_delimiter" >> "$GITHUB_OUTPUT"
  shell: /usr/bin/bash -e {0}
  env:
    COMMIT_HASH_BEFORE: 0000000000000000000000000000000000000000
    COMMIT_HASH_AFTER: ce53820ae585c9f319af72cb9ae3c20e[4](https://github.com/felleslosninger/efm-move-admin/actions/runs/11372468579/job/31637347188#step:4:4)9b4[5](https://github.com/felleslosninger/efm-move-admin/actions/runs/11372468579/job/31637347188#step:4:5)f22

fatal: Invalid revision range 0000000000000000000000000000000000000000..ce53820ae585c9f319af[7](https://github.com/felleslosninger/efm-move-admin/actions/runs/11372468579/job/31637347188#step:4:7)2cb9ae3c20e49b45f22
```