### PR TITLE
PF-1490 Include Quarkus in PR build/test common action

### DIFF
--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -94,8 +94,10 @@ jobs:
           script: |
             core.setFailed('${{ steps.check-pr-title.outputs.error-message }}')
 
-  build-and-test-spring-boot:
-    if: inputs.application-type == 'spring-boot'
+  build-and-test-java:
+    if: |
+      inputs.application-type == 'spring-boot' ||
+      inputs.application-type == 'quarkus'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -169,12 +171,12 @@ jobs:
     if: |
       always() &&
       inputs.enable-auto-merge-dependabot == true &&
-      (needs.build-and-test-spring-boot.result == 'success' || needs.build-and-test-spring-boot.result == 'skipped') &&
+      (needs.build-and-test-java.result == 'success' || needs.build-and-test-java.result == 'skipped') &&
       (needs.call-spring-boot-container-scan.result == 'success' || needs.call-spring-boot-container-scan.result == 'skipped') &&
       (needs.call-quarkus-container-scan.result == 'success' || needs.call-quarkus-container-scan.result == 'skipped')
     needs:
       [
-        build-and-test-spring-boot,
+        build-and-test-java,
         call-spring-boot-container-scan,
         call-quarkus-container-scan,
       ]


### PR DESCRIPTION
The `build-and-test-spring-boot` step should be generic enough for Quarkus PR builds, which is why it is renamed to `build-and-test-java` and now includes the `quarkus`application type. Test this branch in a Quarkus and Spring Boot pipeline before merging to **main**.