### PR TITLE
PF-1516 Enabling imagesigning for all images

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -16,7 +16,7 @@ on:
 
       image-signing:
         description: Flag to toggle image signing on/off - default off
-        default: false
+        default: true
         required: false
         type: boolean
 


### PR DESCRIPTION
Image verification is not turned on. By enabling imagesigning for all images, we are preparing for the next step which is invoking kyverno policy and verify signing for images used in digdir