### PR TITLE
Update test-k6-build-publish-docker.yml

### DIFF
--- a/.github/workflows/test-k6-build-publish-docker.yml
+++ b/.github/workflows/test-k6-build-publish-docker.yml
@@ -38,6 +38,11 @@ jobs:
     outputs:
       imagetag: ${{ steps.output-image-tag.outputs.imagetag }}
       imagedigest: ${{ steps.output-image-digest.outputs.imagedigest }}
+
+    permissions:
+      id-token: write
+      contents: write
+      
     steps:
       - name: Set imagetag as env variable
         run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Giving the required permissions in the workflow so that federated credential can used as intended.