### PR TITLE
Finn jira-id andre steder enn først

### DIFF
--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -72,7 +72,7 @@ jobs:
           GIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           JIID=$(echo "$GIT_MSG" | head -1 |
-          grep -Eo '^([a-zA-Z]{2,6}-[0-9]+)') || JIID=''
+          grep -Eo '([a-zA-Z]{2,6}-[0-9]+)') || JIID=''
           echo "jira-id=$JIID" >> "$GITHUB_ENV"
 
       - name: Get Labels


### PR DESCRIPTION
Slik at også merge commits kan klare å fange opp jira-id