### PR TITLE
PF-1776 - Change cache setup to setup java, and add it to mvn deploy workflows

### DIFF
--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -18,6 +18,10 @@ on:
         default: false
         required: false
         type: boolean
+      cache-path:
+        default: "**/pom.xml"
+        required: false
+        type: string
 
 jobs:
   verify-pull-request-title:
@@ -80,8 +84,10 @@ jobs:
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # pin@v4.7.0
         with:
-          distribution: 'liberica'
+          distribution: "liberica"
           java-version: ${{ inputs.java-version }}
+          cache: maven
+          cache-dependency-path: ${{ inputs.cache-path }}
 
       - name: Configure private NPM registry authentication
         if: ${{ inputs.setup-npm-auth == true }}
@@ -96,12 +102,6 @@ jobs:
         run: |
           mkdir -p ~/.m2
           echo "<settings><servers><server><id>github</id><username>${{ secrets.GH_PACKAGES_READ_USER }}</username><password>${{ secrets.GH_PACKAGES_READ_PAT }}</password></server></servers></settings>" > ~/.m2/settings.xml
-      - name: Cache Maven packages
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
         run: |
           mvn -B clean install --update-snapshots

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -17,6 +17,10 @@ on:
         default: "./"
         required: false
         type: string
+      cache-path:
+        default: "**/pom.xml"
+        required: false
+        type: string
 
 
 jobs:
@@ -109,13 +113,8 @@ jobs:
         with:
           distribution: "liberica"
           java-version: ${{ inputs.java-version }}
-
-      - name: Cache Maven packages
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
+          cache-dependency-path: ${{ inputs.cache-path }}
 
       - uses: s4u/maven-settings-action@64e42c454dbd42ef6370ac8539685755aedd205b # pin@v3.1.0
         with:

--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -23,6 +23,10 @@ on:
         default: ""
         required: false
         type: string
+      cache-path:
+        default: "**/pom.xml"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -37,8 +41,10 @@ jobs:
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # pin@v4.7.0
         with:
-          distribution: 'liberica'
+          distribution: "liberica"
           java-version: ${{ inputs.java-version }}
+          cache: maven
+          cache-dependency-path: ${{ inputs.cache-path }}
 
       - name: Set m2 settings
         run: |

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -35,6 +35,11 @@ on:
         default: false
         required: false
         type: boolean
+      cache-path:
+        default: "**/pom.xml"
+        required: false
+        type: string
+
 
 jobs:
   build:
@@ -42,10 +47,13 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
-      - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # pin@v4.7.0
+      - name: Set up JDK ${{ inputs.java-version }}
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # pin@v4.7.0
         with:
-          java-version: ${{ inputs.java-version }}
           distribution: "liberica"
+          java-version: ${{ inputs.java-version }}
+          cache: maven
+          cache-dependency-path: ${{ inputs.cache-path }}
 
       - name: Configure private NPM registry authentication
         if: ${{ inputs.setup-npm-auth == true }}

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -63,6 +63,10 @@ on:
         required: false
         type: boolean
         default: false
+      cache-path:
+        default: "**/pom.xml"
+        required: false
+        type: string
 
 jobs:
   verify-pull-request-title:
@@ -108,13 +112,8 @@ jobs:
         with:
           distribution: "liberica"
           java-version: ${{ inputs.java-version }}
-
-      - name: Cache Maven packages
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: maven
+          cache-dependency-path: ${{ inputs.cache-path }}
 
       - name: Maven environment setup
         uses: s4u/maven-settings-action@64e42c454dbd42ef6370ac8539685755aedd205b # pin@v3.1.0

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -35,6 +35,10 @@ on:
         default: "./"
         required: false
         type: string
+      cache-path:
+        default: "**/pom.xml"
+        required: false
+        type: string
 
 jobs:
   build-and-scan-image:
@@ -61,6 +65,8 @@ jobs:
         with:
           distribution: "liberica"
           java-version: ${{ inputs.java-version }}
+          cache: maven
+          cache-dependency-path: ${{ inputs.cache-path }}
 
       - name: Configure private NPM registry authentication
         if: ${{ inputs.setup-npm-auth == true }}
@@ -71,13 +77,6 @@ jobs:
           scope: '@felleslosninger'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache Maven packages
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
 
       - name: Maven environment setup
         uses: s4u/maven-settings-action@64e42c454dbd42ef6370ac8539685755aedd205b # pin@v3.1.0


### PR DESCRIPTION
Standardizing caching to `setup-java` implementation to get same cache keys for retrieval across workflowss 