### PR TITLE
PF-1810 Use ArgoCD Kustomize version

### DIFF
--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -35,10 +35,11 @@ on:
       deployment-environment:
         required: true
         type: string
+      # Default should follow ArgoCD version
       kustomize-version:
         required: false
+        default: 5.4.3
         type: string
-        default: "5.0.3"
 
 jobs:
   # Job to prepare payload and set outputs
@@ -97,7 +98,7 @@ jobs:
       - name: Set Dependabot As Jira ID
         id: output-dependabot
         if: |
-          steps.find-jira-id.outputs.match == '' && 
+          steps.find-jira-id.outputs.match == '' &&
           steps.check-dependabot.outputs.dependabot == 'true'
         run: echo "jira-id=Dependabot" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
This will ensure that the correct version of Kustomize is used for the initial `update-version` PR in a CD repository. We should consolidate all Kustomize version usage to a shared workflow to avoid having to update this a lot of places.