### PR TITLE
PF-1867 Add checkout to Dependabot PR automerge workflow

### DIFF
--- a/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
+++ b/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
@@ -28,6 +28,9 @@ jobs:
 
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
+
       - name: Fetch update types
         id: update-types
         env:
@@ -70,6 +73,6 @@ jobs:
               echo "> [!NOTE]"
               echo "> Supported types are:"
               echo "> ${{ inputs.update-types }}"
-            } >> "$GITHUB_STEP_SUMMARY" 
+            } >> "$GITHUB_STEP_SUMMARY"
             echo "merged=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Since Friday, all PRs using our Dependabot automerge has been failing. Something must have changed for Dependabot PRs, but the fix is to ensure we do a Git checkout as part of the workflow to ensure we have a Git context available.

Potential culprit: https://github.blog/news-insights/product-news/dependabot-on-github-actions-and-self-hosted-runners-is-now-generally-available/ (we got a mail about this on Friday)