### PR TITLE
PF-1864 Remove app config yaml linting from common workflows

### DIFF
--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -86,33 +86,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
-      - name: Check if YAML files exist
-        id: yaml-files-exists
-        run: |
-          if [ -f "${{ inputs.application-path }}src/main/resources/application*.y*ml" ]; then
-            echo "file-exists=true" >> "$GITHUB_OUTPUT"
-            echo "- \`${{ inputs.application-path }}src/main/resources/application*.y*ml\` file exists :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"            
-          else
-            echo "file-exists=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "- \`${{ inputs.application-path }}src/main/resources/application*.y*ml\` file exists :x:"
-              echo "  - Skipping yamllint"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Run yamllint
-        if: steps.yaml-files-exists.outputs.file_exists == 'true'
-        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # pin@v3.1.1
-        with:
-          file_or_dir: ${{ inputs.application-path }}src/main/resources/application*.y*ml
-          config_data: |
-            extends: default
-            rules:
-              empty-lines: disable
-              line-length:
-                max: 150
-                level: warning
-
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # pin@v4.7.0
         with:
@@ -135,7 +108,6 @@ jobs:
                 "password": "${{ secrets.MAVEN_PASSWORD }}"
             }]
 
-
       - name: Configure private NPM registry authentication
         if: ${{ inputs.setup-npm-auth == true }}
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # pin@v4.2.0
@@ -149,7 +121,7 @@ jobs:
       - name: Run mvn ${{ inputs.maven-lifecycle }}
         run: |
           LIFECYCLE="${{ inputs.maven-lifecycle }}"
-          case "$LIFECYCLE" in 
+          case "$LIFECYCLE" in
             test|package|verify|install)
               mvn -B "$LIFECYCLE"
               ;;

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -95,18 +95,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
-      - name: yaml-lint
-        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # pin@v3.1.1
-        with:
-          file_or_dir: src/main/resources/application*.y*ml
-          config_data: |
-            extends: default
-            rules:
-              empty-lines: disable
-              line-length:
-                max: 150
-                level: warning
-
       - name: Cache Maven packages
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # pin@v4.2.0
         with:
@@ -270,8 +258,6 @@ jobs:
           cosign attest --yes --predicate ./provenance.json --type slsaprovenance1 "${{ env.IMAGE-NAME }}@${DIGEST}"
         env:
           DIGEST: ${{ env.IMAGE_DIGEST }}
-
-
 
   notify-on-errors:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -118,33 +118,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
-      - name: Check if YAML files exist
-        id: yaml-files-exists
-        run: |
-          if [ -f "${{ inputs.application-path }}src/main/resources/application*.y*ml" ]; then
-            echo "file-exists=true" >> "$GITHUB_OUTPUT"
-            echo "- \`${{ inputs.application-path }}src/main/resources/application*.y*ml\` file exists :white_check_mark:" >> "$GITHUB_STEP_SUMMARY"            
-          else
-            echo "file-exists=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "- \`${{ inputs.application-path }}src/main/resources/application*.y*ml\` file exists :x:"
-              echo "  - Skipping yamllint"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Run yamllint
-        if: steps.yaml-files-exists.outputs.file_exists == 'true'
-        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # pin@v3.1.1
-        with:
-          file_or_dir: ${{ inputs.application-path }}src/main/resources/application*.y*ml
-          config_data: |
-            extends: default
-            rules:
-              empty-lines: disable
-              line-length:
-                max: 150
-                level: warning
-
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # pin@v4.7.0
         with:


### PR DESCRIPTION
The platform team has decided to remove the YAML linting of app config from the common workflows for several reasons

- Third party action is old and not really maintained anymore
- It is better that the developers take responsibility for the kind of linting they want (we can probably have something common if needed, but it should not be part of the other common pipelines)