### PR TITLE
PF-1885 Only run workflow if specific image inputs are non-empty

### DIFF
--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -71,6 +71,14 @@ jobs:
             echo "| kustomize-version       | ${{ inputs.kustomize-version }}       |"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Check important image inputs
+        if: |
+          inputs.image-version == '' ||
+          inputs.image-digest == ''
+        run: |
+          echo "One or more empty image inputs detected. Exiting" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
       - name: Find Jira ID
         id: find-jira-id
         env:


### PR DESCRIPTION
We have seen that if the following are empty for some reason, you end up with a "broken" app in the CD repository

- `image-digest: ${{ needs.build-image.outputs.image-digest }}`
- `image-version: ${{ needs.build-image.outputs.image-version }}`

We need to stop the pipeline if these are empty. These were referencing a non-existing job after actions migration, and GitHub actions happily allow this, causing the required variables to be set to empty strings, which we do not support.

See https://digdir.atlassian.net/browse/PF-1885 for more information.

Test runs for plattform-test-app:

- https://github.com/felleslosninger/plattform-test-app/actions/runs/15758651583/job/44419999368 (wrong reference with empty strings)
- https://github.com/felleslosninger/plattform-test-app/actions/runs/15758764620/job/44420335499 (correct references)

Also note that by adding actionlint to app repos, it will detect the wrong references.