### PR TITLE
PF-1895 Add support for NPM auth for Spring Boot builds

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -52,6 +52,12 @@ on:
         required: false
         type: string
 
+      setup-npm-auth:
+        description: Configure private NPM registry authentication
+        default: false
+        required: false
+        type: boolean
+
       application-type:
         default: "spring-boot"
         required: false
@@ -134,6 +140,7 @@ jobs:
       update-versions: ${{ inputs.update-versions }}
       container-registry: ${{ needs.input-checks.outputs.container-registry }}
       sp-container-registry-client-id: ${{ needs.input-checks.outputs.sp-container-registry-client-id }}
+      setup-npm-auth: ${{ inputs.setup-npm-auth }}
     secrets: inherit
 
   run-quarkus-build:


### PR DESCRIPTION
When migrating to the new best practice https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-call-update-image.yml, we forgot to expose the NPM auth input so that it is propagated down to https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-spring-boot-build-publish-image.yml. This is already a supported input there.