### PR TITLE
PF-2068 Use default artifact-name from anchore/sbom-action in lib workflow

### DIFF
--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -27,9 +27,6 @@ on:
         default: ""
         required: false
         type: string
-      artifact-name:
-        required: false
-        type: string
       setup-npm-auth:
         description: Configure private NPM registry authentication
         default: false
@@ -133,17 +130,11 @@ jobs:
           if [ "${{ inputs.deployment-repository }}" != "" ]; then
             MAVEN_CMD="$MAVEN_CMD -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ inputs.deployment-repository }}"
           fi
-          
+
           cd ${{ inputs.application-path }} # Move into module path if multi module project, default is "./" so no operation if not specified.
 
           $MAVEN_CMD
 
-      - name: Set artifact id
-        id: set-artifact-id
-        run: |
-          echo "artifact-id=${{ inputs.artifact-name }}-${{ github.run_number }}-${{ github.run_attempt }}.spdx" >> "$GITHUB_OUTPUT"
-
       - uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # pin@v0.20.6
         with:
           path: ${{ inputs.sbom-path }}
-          artifact-name: ${{ steps.set-artifact-id.outputs.artifact-id }}


### PR DESCRIPTION
Currently, if **artifact-name** is not overridden for library workflows, the name is empty (the input is not currently mandatory: https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-maven-install-deploy-lib.yml#L31). In these situations, we end up with a borked name for the artifact, and this happens for all workflows that does not override the **artifact-name**. For our normal Maven builds, we do not have this functionality, which means we use the default from `anchore/sbom-action`.