### PR TITLE
Hardening GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -1,4 +1,5 @@
 name: Build and publish Docker image
+permissions: {}
 
 on:
   workflow_call:

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -208,6 +208,9 @@ jobs:
     secrets: inherit
 
   run-quarkus-build:
+    permissions:
+      id-token: write
+      contents: write
     needs: input-checks
     if: inputs.application-type == 'quarkus'
     uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@hardening-gh-token-permissions

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -236,6 +236,9 @@ jobs:
     secrets: inherit
 
   run-docker-build:
+    permissions:
+      id-token: write
+      contents: write
     needs: input-checks
     if: inputs.application-type == 'docker'
     uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@hardening-gh-token-permissions

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -177,10 +177,6 @@ jobs:
             echo "Invalid lifecycle type. Supported types are: \`deployment\`, and \`development\`" >> "$GITHUB_STEP_SUMMARY"
           fi
   run-spring-boot-build:
-    permissions: 
-     contents: write
-     packages: write
-     id-token: write
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
     uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@hardening-gh-token-permissions
@@ -214,7 +210,7 @@ jobs:
   run-quarkus-build:
     needs: input-checks
     if: inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@hardening-gh-token-permissions
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}
@@ -239,7 +235,7 @@ jobs:
   run-docker-build:
     needs: input-checks
     if: inputs.application-type == 'docker'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@hardening-gh-token-permissions
     with:
       image-name: ${{ inputs.image-name }}
       image-signing: ${{ inputs.image-signing }}

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -139,6 +139,7 @@ on:
 
 jobs:
   inputs-to-summary:
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: "Write inputs to summary"
@@ -148,6 +149,7 @@ jobs:
           title: "Inputs"
 
   input-checks:
+    permissions: {}
     runs-on: ubuntu-latest
     outputs:
       container-registry: ${{ steps.set-container-registry.outputs.container-registry }}
@@ -177,6 +179,10 @@ jobs:
             echo "Invalid lifecycle type. Supported types are: \`deployment\`, and \`development\`" >> "$GITHUB_STEP_SUMMARY"
           fi
   run-spring-boot-build:
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
     uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@hardening-gh-token-permissions

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -239,6 +239,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      packages: read
     needs: input-checks
     if: inputs.application-type == 'docker'
     uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@hardening-gh-token-permissions

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -1,8 +1,4 @@
 name: Build and publish Docker image
-permissions: 
-  contents: write
-  packages: write
-  id-token: write
 
 on:
   workflow_call:

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -179,10 +179,6 @@ jobs:
             echo "Invalid lifecycle type. Supported types are: \`deployment\`, and \`development\`" >> "$GITHUB_STEP_SUMMARY"
           fi
   run-spring-boot-build:
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
     uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@hardening-gh-token-permissions

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -176,8 +176,11 @@ jobs:
           else
             echo "Invalid lifecycle type. Supported types are: \`deployment\`, and \`development\`" >> "$GITHUB_STEP_SUMMARY"
           fi
-
   run-spring-boot-build:
+    permissions: 
+     contents: write
+     packages: write
+     id-token: write
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
     uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@hardening-gh-token-permissions

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -1,5 +1,8 @@
 name: Build and publish Docker image
-permissions: {}
+permissions: 
+  contents: write
+  packages: write
+  id-token: write
 
 on:
   workflow_call:

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -179,7 +179,7 @@ jobs:
   run-spring-boot-build:
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@hardening-gh-token-permissions
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -1,4 +1,8 @@
 name: Build/publish Docker image
+permissions:
+  contents: write
+  id-token: write
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -116,6 +116,10 @@ jobs:
           title: "Inputs"
 
   build-publish-image:
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -1,5 +1,4 @@
 name: Build/publish Docker image
-permissions:  {}
 
 on:
   workflow_call:
@@ -113,9 +112,6 @@ jobs:
           title: "Inputs"
 
   build-publish-image:
-    permissions:
-      id-token: write
-      contents: write
       
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -1,8 +1,5 @@
 name: Build/publish Docker image
-permissions:
-  contents: write
-  id-token: write
-  packages: read
+permissions:  {}
 
 on:
   workflow_call:
@@ -119,7 +116,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-      packages: write
+      
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -1,4 +1,8 @@
 name: Build/publish Docker image
+permissions:
+  contents: write
+  id-token: write
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -127,10 +127,6 @@ jobs:
       imagetag: ${{ steps.output-image-tag.outputs.imagetag }}
       imagedigest: ${{ steps.output-image-digest.outputs.imagedigest }}
 
-    permissions:
-      id-token: write
-      contents: write
-
     steps:
       - name: Set imagetag as env variable
         run: echo "IMAGETAG=$(date +'%Y-%m-%d-%H%M')-${GITHUB_SHA::8}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -1,8 +1,5 @@
 name: Build and publish Docker image
-permissions:
-  contents: write
-  id-token: write
-  packages: read
+permissions: {}
 
 on:
   workflow_call:
@@ -133,6 +130,7 @@ on:
 
 jobs:
   inputs-to-summary:
+    permissions: {}
     runs-on: ubuntu-latest
     steps:
       - name: "Write inputs to summary"
@@ -325,6 +323,7 @@ jobs:
           image: ${{ steps.set-image-name.outputs.image-name }}:${{ steps.set-image-tag.outputs.image-tag }}
 
   notify-on-errors:
+    permissions: {}
     runs-on: ubuntu-latest
     needs: [build-publish-image]
     if: always() && contains(needs.*.result, 'failure')

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -1,4 +1,8 @@
 name: Build and publish Docker image
+permissions:
+  contents: write
+  id-token: write
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -140,6 +140,7 @@ jobs:
           title: "Inputs"
 
   build-publish-image:
+    permissions: {}
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.image-tag }}

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -140,16 +140,11 @@ jobs:
           title: "Inputs"
 
   build-publish-image:
+    permissions: {}
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.image-tag }}
       image-digest: ${{ steps.set-image-digest.outputs.image-digest }}
-
-    permissions:
-      id-token: write
-      contents: write
-      packages: write
-
     steps:
       - name: Set image tag
         id: set-image-tag

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -140,10 +140,6 @@ jobs:
           title: "Inputs"
 
   build-publish-image:
-    permissions: 
-     contents: write
-     packages: write
-     id-token: write
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.image-tag }}

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -140,7 +140,10 @@ jobs:
           title: "Inputs"
 
   build-publish-image:
-    permissions: {}
+    permissions: 
+     contents: write
+     packages: write
+     id-token: write
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.image-tag }}

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -140,7 +140,10 @@ jobs:
           title: "Inputs"
 
   build-publish-image:
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.image-tag }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # github-workflows
 
+
 ## Spring boot application workflows
 
 Build application on PR creation: [ci-maven-build.yml](.github/workflows/ci-maven-build.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # github-workflows
 
-
 ## Spring boot application workflows
 
 Build application on PR creation: [ci-maven-build.yml](.github/workflows/ci-maven-build.yml)


### PR DESCRIPTION
Hardening GITHUB_TOKEN permissions (least privilege)

- we started by setting permissions: {} to fully disable all default GITHUB_TOKEN access
- incrementally added only the permissions required for the workflow to succeed, based on observed errors

Why this change?

- reduces risk of accidental or malicious misuse of the token
- aligns with GitHub’s least-privilege security best practices
- makes permissions explicit, auditable, and easier to reason about

Result: a minimal, secure, and maintainable permission set tailored to the workflow’s real requirements

Tested OK using
- ci-spring-boot-build-publish-image.yml using https://github.com/felleslosninger/plattform-test-app/actions/runs/23452000457
- ci-quarkus-build-publish-image.yml using https://github.com/felleslosninger/plattform-test-app-quarkus/actions/runs/23482889666/job/68480742154
- ci-docker-build-publish-image.yml using https://github.com/felleslosninger/plattform-test-app/blob/main/.github/workflows/deploy-dockerfile.yml#L8C62-L8C88