### PR TITLE
PF-2347 Show Trivy results in the action logs (as before)

### DIFF
--- a/.github/actions/trivy-scan/README.md
+++ b/.github/actions/trivy-scan/README.md
@@ -23,8 +23,9 @@ By default we
   individually for the different scans
 - Ignore unfixed vulnerabilities by default to avoid stopping the pipeline when
   there's no fix available yet (but this can be overridden)
-- We hide the full output from the Trivy scan, and move it out to the step
-  summary if there's something you should look at (but this can be overridden)
+- We show the full output from the Trivy scan, and additionally add it out to
+  the step summary if there's something you should look at. It is possible to
+  hide the output in the action logs via inputs
 - Scan for plaintext secrets
 - Disable the noisy VEX notice that is included in scan results
 
@@ -42,11 +43,11 @@ None
 | `library-disable-scan` | Disable library scan | false | `false` |
 | `library-ignore-unfixed` | Ignore unfixed vulnerabilities in library scan | false | `true` |
 | `library-severity` | When to fail the scan with library vulnerabilities | false | `HIGH,CRITICAL` |
-| `library-hide-progress` | Hide progress output for library scan | false | `true` |
+| `library-hide-progress` | Hide progress output for library scan | false | `false` |
 | `os-disable-scan` | Disable OS scan | false | `false` |
 | `os-ignore-unfixed` | Ignore unfixed vulnerabilities in OS scan | false | `true` |
 | `os-severity` | When to fail the scan with OS vulnerabilities | false | `CRITICAL` |
-| `os-hide-progress` | Hide progress output for OS scan | false | `true` |
+| `os-hide-progress` | Hide progress output for OS scan | false | `false` |
 | `os-exit-code` | Exit code when OS vulnerabilities are found (0 = informational, 1 = blocking) | false | `"0"` |
 | `trivy-version` | Version of Trivy to use for scanning | false | `""` |
 | `trivyignore-warning-threshold` | Number of ignored vulnerabilities before we issue a warning | false | `10` |

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: false
   library-hide-progress:
     description: Hide progress output for library scan
-    default: "true"
+    default: "false"
     required: false
   os-disable-scan:
     description: Disable OS scan
@@ -45,7 +45,7 @@ inputs:
     required: false
   os-hide-progress:
     description: Hide progress output for OS scan
-    default: "true"
+    default: "false"
     required: false
   os-exit-code:
     description: Exit code when OS vulnerabilities are found (0 = informational, 1 = blocking)

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -101,7 +101,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -121,7 +121,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -54,7 +54,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -74,7 +74,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
@@ -68,7 +68,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -88,7 +88,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-exit-code:
         description: Exit code for OS vulns (1 = blocking for Dockerfiles)
         type: string

--- a/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
@@ -63,7 +63,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -83,7 +83,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-exit-code:
         description: Exit code for OS vulns (1 = blocking for Dockerfiles)
         type: string

--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -50,7 +50,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -50,7 +50,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -55,7 +55,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -72,7 +72,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -105,7 +105,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -125,7 +125,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -220,7 +220,7 @@ jobs:
     if: |
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2347-add-trivy-results-to-action-logs-by-default
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -220,7 +220,7 @@ jobs:
     if: |
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2347-add-trivy-results-to-action-logs-by-default
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -66,7 +66,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -86,7 +86,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -55,7 +55,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -75,7 +75,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -92,7 +92,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -112,7 +112,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -72,7 +72,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -92,7 +92,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string

--- a/.github/workflows/test-k6-build-docker.yml
+++ b/.github/workflows/test-k6-build-docker.yml
@@ -40,7 +40,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -60,7 +60,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-exit-code:
         description: Exit code for OS vulns (1 = blocking for Dockerfiles)
         type: string

--- a/.github/workflows/test-k6-build-publish-docker.yml
+++ b/.github/workflows/test-k6-build-publish-docker.yml
@@ -45,7 +45,7 @@ on:
         description: Hide progress output for Trivy library scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -65,7 +65,7 @@ on:
         description: Hide progress output for Trivy OS scan
         type: boolean
         required: false
-        default: true
+        default: false
       trivy-os-exit-code:
         description: Exit code for OS vulns (1 = blocking for Dockerfiles)
         type: string


### PR DESCRIPTION
Back by popular demand, we now show the Trivy results in the action logs by default (again). This is how it worked before the new composite action, and developers use this more than we thought. It can be disabled via inputs if needed.