### PR TITLE
Upgrade default builder to Paketo from builder-jammy-java-tiny to builder-noble-java-tiny

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -9,7 +9,7 @@ on:
         type: string
       image-pack:
         description: Paketo builder image to use. See https://paketo.io/docs/reference/builders-reference/ for choices
-        default: builder-jammy-java-tiny
+        default: builder-noble-java-tiny
         required: false
         type: string
       image-pack-tag:

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -35,7 +35,7 @@ on:
         type: string
       image-pack:
         description: Paketo builder image to use. See https://paketo.io/docs/reference/builders-reference/ for choices
-        default: builder-jammy-java-tiny
+        default: builder-noble-java-tiny
         required: false
         type: string
       image-pack-tag:

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -9,7 +9,7 @@ on:
         type: string
       image-pack:
         description: Paketo builder image to use. See https://paketo.io/docs/reference/builders-reference/ for choices
-        default: builder-jammy-java-tiny
+        default: builder-noble-java-tiny
         required: false
         type: string
       image-pack-tag:

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -9,7 +9,7 @@ on:
         type: string
       image-pack:
         description: Paketo builder image to use. See https://paketo.io/docs/reference/builders-reference/ for choices
-        default: builder-jammy-java-tiny
+        default: builder-noble-java-tiny
         required: false
         type: string
       image-pack-tag:

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -9,7 +9,7 @@ on:
         type: string
       image-pack:
         description: Paketo builder image to use. See https://paketo.io/docs/reference/builders-reference/ for choices
-        default: builder-jammy-java-tiny
+        default: builder-noble-java-tiny
         required: false
         type: string
       image-pack-tag:

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -9,7 +9,7 @@ on:
         type: string
       image-pack:
         description: Paketo builder image to use. See https://paketo.io/docs/reference/builders-reference/ for choices
-        default: builder-jammy-java-tiny
+        default: builder-noble-java-tiny
         required: false
         type: string
       image-pack-tag:


### PR DESCRIPTION
This PR upgrades the base builder image for most of our Spring Boot and Quarkus application builds from builder-jammy-java-tiny to builder-noble-java-tiny.

- 	switches base OS from Ubuntu 22.04 (Jammy) to Ubuntu 24.04 (Noble)
- 	provides updated system libraries along with improved security and support lifecycle

No code changes are required, but rebuilt images may have minor differences in size or runtime behavior.
 
Tested here

- 	Quarkus: https://github.com/felleslosninger/plattform-test-app-quarkus/pull/65/changes
- 	Spring Boot: https://github.com/felleslosninger/plattform-test-app/pull/494