### PR TITLE
PF-2352 Skip Paketo dirs for Trivy library scans by default

### DIFF
--- a/.github/actions/trivy-scan/README.md
+++ b/.github/actions/trivy-scan/README.md
@@ -28,6 +28,11 @@ By default we
   hide the output in the action logs via inputs
 - Scan for plaintext secrets
 - Disable the noisy VEX notice that is included in scan results
+- Skip certain dirs in library scanning for dependencies related to Paketo
+  builds (i.e. Spring Boot and Quarkus builds). These are dependencies that
+  developers do not control, and detected vulnerabilities must be added to
+  `.trivyignore` files (which is usually pointless). The dirs are currently
+  hardcoded and must be updated in the composite action
 
 ## Prerequisites
 

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -170,6 +170,7 @@ runs:
         hide-progress: ${{ inputs.library-hide-progress }}
         output: trivy-library-scan.txt
         exit-code: "1"
+        skip-dirs: "layers,cnb"
 
     - name: Publish Trivy library scan output to step summary
       if: ${{ always() && inputs.library-disable-scan != 'true' }}


### PR DESCRIPTION
There are some dependencies (noramally Go binaries) used by Paketo that are picked up during library scans. Since we are always using the latest Paketo images, the only way for developers to proceed with their builds are by adding the detected vulnerabilities to `.trivyignore`. The currently detected directories used by Paketo are

- **layers**
- **cnb**

Example workflow that stops on vulns in these directories: https://github.com/felleslosninger/plattform-test-app/actions/runs/24395447562/attempts/1
Example workflow with skipped dirs: https://github.com/felleslosninger/plattform-test-app/actions/runs/24395447562