### PR TITLE
PF-2347 Actually add Trivy scan results to action logs 

### DIFF
--- a/.github/actions/trivy-scan/README.md
+++ b/.github/actions/trivy-scan/README.md
@@ -23,9 +23,8 @@ By default we
   individually for the different scans
 - Ignore unfixed vulnerabilities by default to avoid stopping the pipeline when
   there's no fix available yet (but this can be overridden)
-- We show the full output from the Trivy scan, and additionally add it out to
-  the step summary if there's something you should look at. It is possible to
-  hide the output in the action logs via inputs
+- We suppress progress bar and log output by default, but add the scan results
+  to both the log output and step summary
 - Scan for plaintext secrets
 - Disable the noisy VEX notice that is included in scan results
 - Skip certain dirs in library scanning for dependencies related to Paketo
@@ -48,11 +47,9 @@ None
 | `library-disable-scan` | Disable library scan | false | `false` |
 | `library-ignore-unfixed` | Ignore unfixed vulnerabilities in library scan | false | `true` |
 | `library-severity` | When to fail the scan with library vulnerabilities | false | `HIGH,CRITICAL` |
-| `library-hide-progress` | Hide progress output for library scan | false | `false` |
 | `os-disable-scan` | Disable OS scan | false | `false` |
 | `os-ignore-unfixed` | Ignore unfixed vulnerabilities in OS scan | false | `true` |
 | `os-severity` | When to fail the scan with OS vulnerabilities | false | `CRITICAL` |
-| `os-hide-progress` | Hide progress output for OS scan | false | `false` |
 | `os-exit-code` | Exit code when OS vulnerabilities are found (0 = informational, 1 = blocking) | false | `"0"` |
 | `trivy-version` | Version of Trivy to use for scanning | false | `""` |
 | `trivyignore-warning-threshold` | Number of ignored vulnerabilities before we issue a warning | false | `10` |
@@ -98,4 +95,4 @@ we want to use.
 This action utilizes a composite run to perform Trivy vulnerability scanning. It
 validates inputs, checks for `.trivyignore` files, runs library scans (for both
 image and fs types), and OS scans (for image type only). Results are published
-to the GitHub step summary with expandable details.
+to the GitHub step summary.

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -167,7 +167,7 @@ runs:
         severity: "${{ inputs.library-severity }}"
         ignore-unfixed: ${{ inputs.library-ignore-unfixed }}
         trivyignores: ${{ steps.trivyignore.outputs.trivyignore-path }}
-        hide-progress: ${{ inputs.library-hide-progress }}
+        hide-progress: true
         output: trivy-library-scan.txt
         exit-code: "1"
         skip-dirs: "layers,cnb"
@@ -221,7 +221,7 @@ runs:
         severity: "${{ inputs.os-severity }}"
         ignore-unfixed: ${{ inputs.os-ignore-unfixed }}
         trivyignores: ${{ steps.trivyignore.outputs.trivyignore-path }}
-        hide-progress: ${{ inputs.os-hide-progress }}
+        hide-progress: true
         output: trivy-os-scan.txt
         exit-code: "${{ inputs.os-exit-code }}"
         # Skip Trivy setup if library scan is not enabled, as the OS scan also

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -27,10 +27,6 @@ inputs:
     description: When to fail the scan with library vulnerabilities
     default: "HIGH,CRITICAL"
     required: false
-  library-hide-progress:
-    description: Hide progress output for library scan
-    default: "true"
-    required: false
   os-disable-scan:
     description: Disable OS scan
     default: "false"
@@ -42,10 +38,6 @@ inputs:
   os-severity:
     description: When to fail the scan with OS vulnerabilities
     default: "CRITICAL"
-    required: false
-  os-hide-progress:
-    description: Hide progress output for OS scan
-    default: "true"
     required: false
   os-exit-code:
     description: Exit code when OS vulnerabilities are found (0 = informational, 1 = blocking)

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -180,11 +180,10 @@ runs:
       run: |
         if [[ -s trivy-library-scan.txt ]]; then
 
-          echo "==============================================================="
+          echo "=========================="
           echo "TRIVY LIBRARY SCAN RESULTS"
-          echo "==============================================================="
+          echo "=========================="
           cat trivy-library-scan.txt
-          echo "==============================================================="
           echo "Note: This table is also available in the workflow Summary tab."
           echo ""
 
@@ -239,11 +238,10 @@ runs:
       run: |
         if [[ -s trivy-os-scan.txt ]]; then
 
-          echo "==============================================================="
-          echo "TRIVY OS SCAN RESULTS"
-          echo "==============================================================="
-          cat trivy-os-scan.txt
-          echo "==============================================================="
+          echo "=========================="
+          echo "TRIVY LIBRARY SCAN RESULTS"
+          echo "=========================="
+          cat trivy-library-scan.txt
           echo "Note: This table is also available in the workflow Summary tab."
           echo ""
 

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: false
   library-hide-progress:
     description: Hide progress output for library scan
-    default: "false"
+    default: "true"
     required: false
   os-disable-scan:
     description: Disable OS scan
@@ -45,7 +45,7 @@ inputs:
     required: false
   os-hide-progress:
     description: Hide progress output for OS scan
-    default: "false"
+    default: "true"
     required: false
   os-exit-code:
     description: Exit code when OS vulnerabilities are found (0 = informational, 1 = blocking)

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -230,10 +230,10 @@ runs:
       run: |
         if [[ -s trivy-os-scan.txt ]]; then
 
-          echo "=========================="
-          echo "TRIVY LIBRARY SCAN RESULTS"
-          echo "=========================="
-          cat trivy-library-scan.txt
+          echo "====================="
+          echo "TRIVY OS SCAN RESULTS"
+          echo "====================="
+          cat trivy-os-scan.txt
           echo "Note: This table is also available in the workflow Summary tab."
           echo ""
 

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -179,6 +179,15 @@ runs:
         SCAN_OUTCOME: ${{ steps.trivy-library.outcome }}
       run: |
         if [[ -s trivy-library-scan.txt ]]; then
+
+          echo "==============================================================="
+          echo "TRIVY LIBRARY SCAN RESULTS"
+          echo "==============================================================="
+          cat trivy-library-scan.txt
+          echo "==============================================================="
+          echo "Note: This table is also available in the workflow Summary tab."
+          echo ""
+
           {
             echo "#### Library scan results"
 
@@ -229,6 +238,15 @@ runs:
         OS_EXIT_CODE: ${{ inputs.os-exit-code }}
       run: |
         if [[ -s trivy-os-scan.txt ]]; then
+
+          echo "==============================================================="
+          echo "TRIVY OS SCAN RESULTS"
+          echo "==============================================================="
+          cat trivy-os-scan.txt
+          echo "==============================================================="
+          echo "Note: This table is also available in the workflow Summary tab."
+          echo ""
+
           {
             echo "#### OS scan results"
 

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -220,7 +220,7 @@ jobs:
   run-docker-build:
     needs: input-checks
     if: inputs.application-type == 'docker'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@PF-2347-actually-add-scan-results-to-action-logs
+    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@main
     with:
       image-name: ${{ inputs.image-name }}
       image-signing: ${{ inputs.image-signing }}

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -220,7 +220,7 @@ jobs:
   run-docker-build:
     needs: input-checks
     if: inputs.application-type == 'docker'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@PF-2347-actually-add-scan-results-to-action-logs
     with:
       image-name: ${{ inputs.image-name }}
       image-signing: ${{ inputs.image-signing }}

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -97,11 +97,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -117,11 +112,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -198,11 +188,9 @@ jobs:
       trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
       trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
       trivy-library-severity: ${{ inputs.trivy-library-severity }}
-      trivy-library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
       trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
       trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
       trivy-os-severity: ${{ inputs.trivy-os-severity }}
-      trivy-os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
       trivy-version: ${{ inputs.trivy-version }}
     secrets: inherit
 
@@ -223,11 +211,9 @@ jobs:
       trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
       trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
       trivy-library-severity: ${{ inputs.trivy-library-severity }}
-      trivy-library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
       trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
       trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
       trivy-os-severity: ${{ inputs.trivy-os-severity }}
-      trivy-os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
       trivy-version: ${{ inputs.trivy-version }}
     secrets: inherit
 
@@ -246,10 +232,8 @@ jobs:
       trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
       trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
       trivy-library-severity: ${{ inputs.trivy-library-severity }}
-      trivy-library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
       trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
       trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
       trivy-os-severity: ${{ inputs.trivy-os-severity }}
-      trivy-os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
       trivy-version: ${{ inputs.trivy-version }}
     secrets: inherit

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Run Trivy vulnerability scanner
-        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@PF-2347-actually-add-scan-results-to-action-logs
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           image-ref: ${{ steps.set-image-name.outputs.image-name }}:${{ steps.set-image-tag.outputs.image-tag }}
           application-path: ${{ inputs.application-path }}

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -50,11 +50,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -70,11 +65,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -143,11 +133,9 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           os-exit-code: "1"
           trivy-version: ${{ inputs.trivy-version }}
 

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Run Trivy vulnerability scanner
-        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@PF-2347-actually-add-scan-results-to-action-logs
         with:
           image-ref: ${{ steps.set-image-name.outputs.image-name }}:${{ steps.set-image-tag.outputs.image-tag }}
           application-path: ${{ inputs.application-path }}

--- a/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
@@ -64,11 +64,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -84,11 +79,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-exit-code:
         description: Exit code for OS vulns (1 = blocking for Dockerfiles)
         type: string
@@ -167,11 +157,9 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           os-exit-code: ${{ inputs.trivy-os-exit-code }}
           trivy-version: ${{ inputs.trivy-version }}
 

--- a/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
@@ -59,11 +59,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -79,11 +74,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-exit-code:
         description: Exit code for OS vulns (1 = blocking for Dockerfiles)
         type: string
@@ -173,11 +163,9 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           os-exit-code: ${{ inputs.trivy-os-exit-code }}
           trivy-version: ${{ inputs.trivy-version }}
 

--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -46,11 +46,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -149,7 +144,6 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           trivy-version: ${{ inputs.trivy-version }}
 
       - uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # pin@v0.20.6

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -46,11 +46,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -168,5 +163,4 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           trivy-version: ${{ inputs.trivy-version }}

--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -51,11 +51,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -87,7 +82,6 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           trivy-version: ${{ inputs.trivy-version }}
 
       - name: Set m2 settings

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -68,11 +68,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -134,7 +129,6 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           trivy-version: ${{ inputs.trivy-version }}
 
       - name: Overwrite m2 settings to publish libs

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -101,11 +101,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -121,11 +116,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -230,11 +220,9 @@ jobs:
       trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
       trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
       trivy-library-severity: ${{ inputs.trivy-library-severity }}
-      trivy-library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
       trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
       trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
       trivy-os-severity: ${{ inputs.trivy-os-severity }}
-      trivy-os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
       trivy-version: ${{ inputs.trivy-version }}
     secrets: inherit
 
@@ -254,11 +242,9 @@ jobs:
       trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
       trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
       trivy-library-severity: ${{ inputs.trivy-library-severity }}
-      trivy-library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
       trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
       trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
       trivy-os-severity: ${{ inputs.trivy-os-severity }}
-      trivy-os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
       trivy-version: ${{ inputs.trivy-version }}
     secrets: inherit
 

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -220,7 +220,7 @@ jobs:
     if: |
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2347-actually-add-scan-results-to-action-logs
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -210,7 +210,7 @@ jobs:
     if: |
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2347-actually-add-scan-results-to-action-logs
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -62,11 +62,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -82,11 +77,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -205,11 +195,9 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           trivy-version: ${{ inputs.trivy-version }}
 
       - name: Create SBOM artifact-name

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -51,11 +51,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -71,11 +66,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -177,9 +167,7 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           trivy-version: ${{ inputs.trivy-version }}

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -88,11 +88,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -108,11 +103,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -243,11 +233,9 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           trivy-version: ${{ inputs.trivy-version }}
 
       - name: Create SBOM artifact name
@@ -298,7 +286,6 @@ jobs:
         run: az acr login --name "$ACR_NAME"
         env:
           ACR_NAME: ${{ inputs.container-registry }}
-
 
       - name: Push image
         run: docker push ${{ steps.set-image-name.outputs.image-name }}:${{ steps.set-image-tag.outputs.image-tag }}

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -68,11 +68,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -88,11 +83,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-version:
         description: Version of Trivy to use for scanning
         type: string
@@ -168,9 +158,7 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           trivy-version: ${{ inputs.trivy-version }}

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -161,7 +161,7 @@ jobs:
         run: mvn -DskipTests -B spring-boot:build-image --file ${{ inputs.application-path }}pom.xml -Dspring-boot.build-image.imageName=${{ steps.set-image-name.outputs.image-name }}:${{ steps.set-image-tag.outputs.image-tag }} -Dspring-boot.build-image.builder=paketobuildpacks/${{ inputs.image-pack }}:${{ inputs.image-pack-tag }}
 
       - name: Run Trivy vulnerability scanner
-        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@PF-2347-actually-add-scan-results-to-action-logs
         with:
           image-ref: ${{ steps.set-image-name.outputs.image-name }}:${{ steps.set-image-tag.outputs.image-tag }}
           application-path: ${{ inputs.application-path }}

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -151,7 +151,7 @@ jobs:
         run: mvn -DskipTests -B spring-boot:build-image --file ${{ inputs.application-path }}pom.xml -Dspring-boot.build-image.imageName=${{ steps.set-image-name.outputs.image-name }}:${{ steps.set-image-tag.outputs.image-tag }} -Dspring-boot.build-image.builder=paketobuildpacks/${{ inputs.image-pack }}:${{ inputs.image-pack-tag }}
 
       - name: Run Trivy vulnerability scanner
-        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@PF-2347-actually-add-scan-results-to-action-logs
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           image-ref: ${{ steps.set-image-name.outputs.image-name }}:${{ steps.set-image-tag.outputs.image-tag }}
           application-path: ${{ inputs.application-path }}

--- a/.github/workflows/test-k6-build-docker.yml
+++ b/.github/workflows/test-k6-build-docker.yml
@@ -36,11 +36,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -56,11 +51,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-exit-code:
         description: Exit code for OS vulns (1 = blocking for Dockerfiles)
         type: string
@@ -106,10 +96,8 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           os-exit-code: ${{ inputs.trivy-os-exit-code }}
           trivy-version: ${{ inputs.trivy-version }}

--- a/.github/workflows/test-k6-build-publish-docker.yml
+++ b/.github/workflows/test-k6-build-publish-docker.yml
@@ -41,11 +41,6 @@ on:
         type: string
         required: false
         default: 'HIGH,CRITICAL'
-      trivy-library-hide-progress:
-        description: Hide progress output for Trivy library scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-disable-scan:
         description: Disable Trivy OS scan
         type: boolean
@@ -61,11 +56,6 @@ on:
         type: string
         required: false
         default: 'CRITICAL'
-      trivy-os-hide-progress:
-        description: Hide progress output for Trivy OS scan
-        type: boolean
-        required: false
-        default: false
       trivy-os-exit-code:
         description: Exit code for OS vulns (1 = blocking for Dockerfiles)
         type: string
@@ -135,11 +125,9 @@ jobs:
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
-          library-hide-progress: ${{ inputs.trivy-library-hide-progress }}
           os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
           os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
           os-severity: ${{ inputs.trivy-os-severity }}
-          os-hide-progress: ${{ inputs.trivy-os-hide-progress }}
           os-exit-code: ${{ inputs.trivy-os-exit-code }}
           trivy-version: ${{ inputs.trivy-version }}
 


### PR DESCRIPTION
I completely misunderstood the purpose of the `hide-progress` input to Trivy Action. This will only suppress progress bars and other log output. The actual scan results were hidden because of using the `output` input, which only writes results to file (and then we use the file to add results to the step summary). Because of this we now `cat` the scan result files to the logs by default, and completely remove the `hide-progress` inputs (we just hardcode this to `true` in the composite action to hide unneeded logs anyway).

Example run (with hardcoded suppression and results in logs): https://github.com/felleslosninger/plattform-test-app/actions/runs/24402998645/job/71332145643

PS! We still also add the results to the step summary 