### PR TITLE
PF-2354 Add credentials to mvn versions steps

### DIFF
--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -89,6 +89,9 @@ jobs:
           trivy-version: ${{ inputs.trivy-version }}
 
       - name: Set version
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ inputs.package-version }}" != "" ]; then
             mvn versions:set -B -DnewVersion="${{ inputs.package-version }}"

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -103,6 +103,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set version
+        env:
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
         run: |
           if [ "${{ inputs.package-version }}" != "" ]; then
             mvn versions:set -B -DnewVersion="${{ inputs.package-version }}"

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -147,6 +147,9 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Maven update version used in application.yaml
+        env:
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: mvn versions:set -B -DnewVersion="$IMAGETAG"
 
       - name: Install pack

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -177,6 +177,9 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Maven update version used in application.yaml
+        env:
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
           if [ "${{ inputs.update-versions }}" == "true" ]; then
             mvn versions:set -B -DnewVersion="${{ steps.set-image-tag.outputs.image-tag }}"


### PR DESCRIPTION
I was under the false assumption that the credentials wasn't needed in the `mvn versions` step, but I was wrong: https://github.com/felleslosninger/eproc-elma/actions/runs/24570900716. This adds the same credentials used for Maven build/deploy commands.