### PR TITLE
PF-2361 Remove unused NPM functionality

### DIFF
--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -18,11 +18,6 @@ on:
         default: ./target/
         required: false
         type: string
-      setup-npm-auth:
-        description: Configure private NPM registry authentication
-        default: false
-        required: false
-        type: boolean
       cache-path:
         default: "**/pom.xml"
         required: false
@@ -119,16 +114,6 @@ jobs:
           server-id: github
           server-username: GH_PACKAGES_READ_USER
           server-password: GH_PACKAGES_READ_PAT
-
-      - name: Configure private NPM registry authentication
-        if: ${{ inputs.setup-npm-auth == true }}
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # pin@v5.0.0
-        with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@felleslosninger'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build with Maven
         env:

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -13,11 +13,6 @@ on:
         default: "liberica"
         required: false
         type: string
-      setup-npm-auth:
-        description: Configure private NPM registry authentication
-        default: false
-        required: false
-        type: boolean
       application-path:
         default: "./"
         required: false
@@ -120,16 +115,6 @@ jobs:
           server-id: github
           server-username: MAVEN_USER
           server-password: MAVEN_PASSWORD
-
-      - name: Configure private NPM registry authentication
-        if: ${{ inputs.setup-npm-auth == true }}
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # pin@v5.0.0
-        with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@felleslosninger'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run mvn ${{ inputs.maven-lifecycle }}
         env:

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -35,11 +35,6 @@ on:
       artifact-name:
         required: false
         type: string
-      setup-npm-auth:
-        description: Configure private NPM registry authentication
-        default: false
-        required: false
-        type: boolean
       cache-path:
         default: "**/pom.xml"
         required: false
@@ -91,16 +86,6 @@ jobs:
           server-id: github
           server-username: GH_PACKAGES_READ_USER
           server-password: GH_PACKAGES_READ_PAT
-
-      - name: Configure private NPM registry authentication
-        if: ${{ inputs.setup-npm-auth == true }}
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # pin@v5.0.0
-        with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@felleslosninger'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set version
         env:

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -58,11 +58,6 @@ on:
         default: "true"
         required: false
         type: string
-      setup-npm-auth:
-        description: Configure private NPM registry authentication
-        default: false
-        required: false
-        type: boolean
       container-registry:
         description: Container Registry url
         default: "creiddev.azurecr.io"
@@ -187,16 +182,6 @@ jobs:
           else
             echo "- \`mvn versions\` was not executed" >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: Configure private NPM registry authentication
-        if: ${{ inputs.setup-npm-auth == true }}
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # pin@v5.0.0
-        with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@felleslosninger'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image with Maven/Spring Boot (module-name)
         if: inputs.module-name != ''

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -36,11 +36,6 @@ on:
         description: Container-scan is default download updated CVE definitions via Trivy, enable offline on download problems
         default: false
         type: boolean
-      setup-npm-auth:
-        description: Configure private NPM registry authentication
-        default: false
-        required: false
-        type: boolean
       application-path:
         default: "./"
         required: false
@@ -119,16 +114,6 @@ jobs:
           server-id: github
           server-username: MAVEN_USER
           server-password: MAVEN_PASSWORD
-
-      - name: Configure private NPM registry authentication
-        if: ${{ inputs.setup-npm-auth == true }}
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # pin@v5.0.0
-        with:
-          node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@felleslosninger'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image with Maven (module-name, skips tests)
         if: inputs.module-name != ''


### PR DESCRIPTION
This will remove all `setup-node` action usage for authenticating to internal NPM registry. This was used at some point by MinID, but is no longer used. If this ever is needed again we will add it via a composite action instead. This PR should not be merged until **setup-npm-auth** inputs are removed from the 4 repos from this search: https://github.com/search?q=enterprise%3Adigdir+setup-npm-auth+NOT+repo%3Afelleslosninger%2Fgithub-workflows+NOT+repo%3Afelleslosninger%2Fpaotvers.io&type=code

Added in https://github.com/felleslosninger/github-workflows/pull/196