### PR TITLE
PF-2373 Add permissions to dev deploy workflow (crutvikling)

### DIFF
--- a/.github/workflows/misc-publish-dev-docker.yml
+++ b/.github/workflows/misc-publish-dev-docker.yml
@@ -1,5 +1,7 @@
 name: dev.docker build and release to crutvikling (Azure container registry)
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/misc-publish-dev-docker.yml
+++ b/.github/workflows/misc-publish-dev-docker.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   docker-build-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       REPOSITORY-NAME: ${{ github.event.repository.name }}
     steps:


### PR DESCRIPTION
This adds the necessary permissions for the Dockerfile dev workflow used to push images to **crutvikling**. It only needs permissions to read the application repo, which is why **contents:read** is added. We always reset permissions at the top to ensure least-privilege access per **job**.

Testing:

- plattform-test-app is set to `read`, and the dev deploy workflow is set up to use this branch in **main**: https://github.com/felleslosninger/plattform-test-app/blob/main/.github/workflows/deploy-dev.yml
- This run uses this branch for building a **dev** image: https://github.com/felleslosninger/plattform-test-app/actions/runs/25158510806
- This proves that we do not need any additional permissions changes for the dev workflow in app repos, even when updting the common workflow (this is because it does not need any write permissions)
