### PR TITLE
PF-2376 Add permissions to PR label workflow

### DIFF
--- a/.github/workflows/on-pr-label.yml
+++ b/.github/workflows/on-pr-label.yml
@@ -1,5 +1,7 @@
 name: On PR label
 
+permissions: {}
+
 on:
   workflow_call:
 

--- a/.github/workflows/on-pr-label.yml
+++ b/.github/workflows/on-pr-label.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   append-internal-commit-string-to-title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.event.label.name == 'internal'
     steps:
       - name: Append ${{ env.internal-commit-string }} to PR title


### PR DESCRIPTION
This adds the necessary permissions for the PR label workflow that devs use to append **(INTERNAL-COMMIT)** strings to PR titles automatically. It needs **pull-requests:write** for this. We always reset permissions at the top to ensure least-privilege access per **job**.

This change will require an update to all app workflows that uses the PR label workflow: https://github.com/search?q=enterprise%3Adigdir+on-pr-label.yml++NOT+is%3Aarchived+NOT+repo%3Afelleslosninger%2Fpaotvers.io+NOT+repo%3Afelleslosninger%2Fgithub-workflows+NOT+repo%3Afelleslosninger%2Fchangelog&type=code

Testing:

- First, the PR label workflow for plattform-test-app was updated on **main** like this: https://github.com/felleslosninger/plattform-test-app/blob/main/.github/workflows/on-pr-label.yml (using this branch)
- plattform-test-app is set to `read`, and this PR has the `internal` GitHub label added: https://github.com/felleslosninger/plattform-test-app/pull/503 (the PR branch is also updated to include the permissions update for the PR label workflow: https://github.com/felleslosninger/plattform-test-app/commit/377cbfd6563927654c763a009b46ab1fe5bb41c1)
- By adding the `internal` label, it triggered this workflow which updated the PR title with `(INTERNAL-COMMIT)`: https://github.com/felleslosninger/plattform-test-app/actions/runs/25162583937
- This proves that this workflow works when the app repo is read, and the PR label workflow is updated to have **pull-requests:write** permission
