### PR TITLE
PF-2364 Add permissions to image build workflow

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -226,6 +226,9 @@ jobs:
     needs: input-checks
     if: inputs.application-type == 'docker'
     uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@main
+    permissions:
+      contents: write
+      id-token: write
     with:
       image-name: ${{ inputs.image-name }}
       image-signing: ${{ inputs.image-signing }}

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -166,6 +166,10 @@ jobs:
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
     uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@main
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -198,6 +198,9 @@ jobs:
     needs: input-checks
     if: inputs.application-type == 'quarkus'
     uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@main
+    permissions:
+      contents: write
+      id-token: write
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -1,5 +1,7 @@
 name: Build and publish Docker image
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
This adds the necessary permissions for the image build workflows which is used by devs to build and deploy images. We reset permissions at the top to ensure least-privilege access per job.

**Testing ci-build-publish-image:**

First test running ci-build-publish-image with empty permissions: https://github.com/felleslosninger/plattform-test-app/actions/runs/25309491523 - it crashes due to missing permissions in ci-spring-boot-build-publish-image, so we add them. 

Try to run again: https://github.com/felleslosninger/plattform-test-app/actions/runs/25309885782 - it crashes due to missing permissions in ci-quarkus-build-publish-image, so we add them. 

Try to run again: https://github.com/felleslosninger/plattform-test-app/actions/runs/25310083958 - it crashes due to missing permissions in ci-docker-build-publish-image, so we add them. 

Try to run again: https://github.com/felleslosninger/plattform-test-app/actions/runs/25310201837 - it now runs as expected. 