### PR TITLE
PF-2365 Add permissions for image build PR workflows

### DIFF
--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -5,6 +5,8 @@
 
 name: PR Checks
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -163,6 +163,9 @@ jobs:
       inputs.application-type == 'spring-boot' ||
       inputs.application-type == 'quarkus'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -211,7 +211,7 @@ jobs:
     if: |
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2365-pr-checks-permissions
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
     permissions:
       contents: read
     with:
@@ -235,7 +235,7 @@ jobs:
     if: |
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@PF-2365-pr-checks-permissions
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
     permissions:
       contents: read
     with:
@@ -268,7 +268,7 @@ jobs:
         call-spring-boot-container-scan,
         call-quarkus-container-scan,
       ]
-    uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@PF-2365-pr-checks-permissions
+    uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -262,6 +262,11 @@ jobs:
         call-quarkus-container-scan,
       ]
     uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@main
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      repository-projects: read
     with:
       update-types: ${{ inputs.auto-merge-types }}
     secrets: inherit

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -269,8 +269,8 @@ jobs:
         call-quarkus-container-scan,
       ]
     uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@PF-2365-pr-checks-permissions
-    # permissions:
-    #   contents: write
+    permissions:
+      contents: write
     #   issues: write
     #   pull-requests: write
     #   repository-projects: read

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -163,8 +163,8 @@ jobs:
       inputs.application-type == 'spring-boot' ||
       inputs.application-type == 'quarkus'
     runs-on: ubuntu-latest
-    # permissions:
-    #   contents: read
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -212,6 +212,8 @@ jobs:
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'spring-boot'
     uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2365-pr-checks-permissions
+    permissions:
+      contents: read
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -163,8 +163,8 @@ jobs:
       inputs.application-type == 'spring-boot' ||
       inputs.application-type == 'quarkus'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    # permissions:
+    #   contents: read
 
     steps:
       - name: Checkout
@@ -211,7 +211,7 @@ jobs:
     if: |
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2365-pr-checks-permissions
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}
@@ -233,7 +233,7 @@ jobs:
     if: |
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@PF-2365-pr-checks-permissions
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}
@@ -264,12 +264,12 @@ jobs:
         call-spring-boot-container-scan,
         call-quarkus-container-scan,
       ]
-    uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@main
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      repository-projects: read
+    uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@PF-2365-pr-checks-permissions
+    # permissions:
+    #   contents: write
+    #   issues: write
+    #   pull-requests: write
+    #   repository-projects: read
     with:
       update-types: ${{ inputs.auto-merge-types }}
     secrets: inherit

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -271,9 +271,7 @@ jobs:
     uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@PF-2365-pr-checks-permissions
     permissions:
       contents: write
-    #   issues: write
-    #   pull-requests: write
-    #   repository-projects: read
+      pull-requests: write
     with:
       update-types: ${{ inputs.auto-merge-types }}
     secrets: inherit

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -236,6 +236,8 @@ jobs:
       inputs.enable-trivy-image-scan == true &&
       inputs.application-type == 'quarkus'
     uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@PF-2365-pr-checks-permissions
+    permissions:
+      contents: read
     with:
       image-name: ${{ inputs.image-name }}
       image-pack: ${{ inputs.image-pack }}

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -1,5 +1,7 @@
 name: Container scan
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -86,6 +86,8 @@ on:
 jobs:
   build-and-scan-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       REPOSITORY-NAME: ${{ github.event.repository.name }}
       DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -1,5 +1,7 @@
 name: Container scan
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -89,6 +89,8 @@ on:
 jobs:
   build-and-scan-image:
     runs-on: ubuntu-latest
+    permissions: 
+      contents: read
     env:
       REPOSITORY-NAME: ${{ github.event.repository.name }}
       DOCKLE_HOST: "unix:///var/run/docker.sock"

--- a/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
+++ b/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
@@ -1,6 +1,8 @@
 ---
 name: Dependabot Approve and Merge
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -13,11 +15,11 @@ on:
       merged:
         value: ${{ jobs.dependabot.outputs.merged }}
 
-permissions:
-  pull-requests: write
-  contents: write
-  issues: write
-  repository-projects: read
+# permissions:
+#   pull-requests: write
+#   contents: write
+#   issues: write
+#   repository-projects: read
 
 jobs:
   dependabot:

--- a/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
+++ b/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
@@ -15,16 +15,17 @@ on:
       merged:
         value: ${{ jobs.dependabot.outputs.merged }}
 
-# permissions:
-#   pull-requests: write
-#   contents: write
-#   issues: write
-#   repository-projects: read
 
 jobs:
   dependabot:
     name: Auto approve
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+  #   pull-requests: write
+  #   contents: write
+  #   issues: write
+  #   repository-projects: read
     outputs:
       merged: ${{ steps.write-summary.outputs.merged }}
 

--- a/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
+++ b/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
@@ -22,10 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-  #   pull-requests: write
-  #   contents: write
-  #   issues: write
-  #   repository-projects: read
+      pull-requests: write
     outputs:
       merged: ${{ steps.write-summary.outputs.merged }}
 


### PR DESCRIPTION
This adds the necessary permissions for the image build PR workflows which is used by devs to perform checks on PRs. We reset permissions at the top to ensure least-privilege access per job.

**Testing:**
First trying to run the workflow with no permissions: https://github.com/felleslosninger/plattform-test-app/actions/runs/25428598661 - We see it fails in the checkout step, which means we must add contents: read for the build-and-test-java job and the build-and-scan-image job. 

After adding contents:read to the relevant jobs in ci-pr-checks.yml, we see that build-and-scan-image still fails, since ci-spring-boot-container-scan.yml has reset permissions - so we must add read permissions in this file aswell. And it now works: https://github.com/felleslosninger/plattform-test-app/actions/runs/25429170313 .

Similarly, ci-quarkus-container-scan.yml needs contents: read permissions:
- Without read (fails): https://github.com/felleslosninger/plattform-test-app-quarkus/actions/runs/25429401909 
- With read (works): https://github.com/felleslosninger/plattform-test-app-quarkus/actions/runs/25429866865 

Then we also have to test misc-approve-and-merge-dependabot-pr.yml, which we see atleast requires contents: write. But this is not enough, it fails in the dependabot metadata step: https://github.com/felleslosninger/plattform-test-app/actions/runs/25434128174/attempts/1 

Adding pull-request: write in both ci-pr-check.yml and misc-approve-and-merge-dependabot-pr.yml, we see it now works: https://github.com/felleslosninger/plattform-test-app/actions/runs/25437707785/job/74621211865 