### PR TITLE
PF-2370 Add permissions to Maven build PR workflows

### DIFF
--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -103,10 +103,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0
       - name: Set up JDK ${{ inputs.java-version }}

--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -1,5 +1,7 @@
 name: Maven build java
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -101,6 +103,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -1,5 +1,7 @@
 name: Maven build java
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -101,6 +103,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0


### PR DESCRIPTION
This resets and adds permissions to Maven build PR workflows. No changes will be necessary in app repos for these workflows.

Testing:

- **ci-maven-build-lib.yml**: https://github.com/felleslosninger/plattform-test-app/actions/runs/25492275242 ([workflow with branch](https://github.com/felleslosninger/plattform-test-app/actions/runs/25492275242/workflow))
- **ci-maven-build.yml**: https://github.com/felleslosninger/plattform-test-app/actions/runs/25492275378 ([workflow with branch](https://github.com/felleslosninger/plattform-test-app/actions/runs/25492275378/workflow))