### PR TITLE
PF-2371 Add permissions to Maven build/publish workflows

### DIFF
--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -1,5 +1,7 @@
 name: Release to github packages
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -61,8 +63,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: write
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -1,5 +1,7 @@
 name: Release to github packages
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -71,6 +73,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # pin@v5.0.0
         with:


### PR DESCRIPTION
This resets and adds permissions to Maven build/publish workflows. This will require changes in app repo workflows.

Testing:

- **ci-maven-install-deploy-lib.yml**: https://github.com/felleslosninger/plattform-test-app/actions/runs/25495504695/job/74814054946 ([workflow with branch](https://github.com/felleslosninger/plattform-test-app/actions/runs/25495504695/workflow))
- **ci-maven-deploy.yml**:https://github.com/felleslosninger/plattform-test-app/actions/runs/25495958797/job/74815622881 ([workflow with branch](https://github.com/felleslosninger/plattform-test-app/actions/runs/25495958797/workflow))