### PR TITLE
PF-2372 Clean up and fix permissions for custom workflows

### DIFF
--- a/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
@@ -1,5 +1,7 @@
 name: Build, scan and publish Docker image
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -113,9 +115,9 @@ jobs:
       image-digest: ${{ steps.set-image-digest.outputs.image-digest }}
 
     permissions:
-      id-token: write
-      contents: write
+      contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
@@ -1,5 +1,7 @@
 name: Build and scan Docker image
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -103,9 +105,7 @@ jobs:
       image-tag: ${{ steps.set-image-tag.outputs.image-tag }}
 
     permissions:
-      id-token: write
-      contents: write
-      packages: write
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-k6-build-docker.yml
+++ b/.github/workflows/test-k6-build-docker.yml
@@ -1,5 +1,7 @@
 name: Build k6-docker
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -65,6 +67,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       REPOSITORY-NAME: ${{ github.event.repository.name }}
       REGISTRY_URL: my-local-registry

--- a/.github/workflows/test-k6-build-publish-docker.yml
+++ b/.github/workflows/test-k6-build-publish-docker.yml
@@ -1,5 +1,7 @@
 name: Build/publish Docker image
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -86,8 +88,8 @@ jobs:
       imagedigest: ${{ steps.output-image-digest.outputs.imagedigest }}
 
     permissions:
+      contents: read
       id-token: write
-      contents: write
 
     steps:
       - name: Set imagetag as env variable


### PR DESCRIPTION
This resets and adds and/or fixes permissions in custom workflows. Some changes will be necessary in app repos using these workflows.

This is difficult to test without help. We should consider merging this, and fixing errors if necessary (after **read** is enforced on the org. level).

- The build/publish workflows does not seem to need **contents: write**, so this has been downgraded
- The build/scan workflows only need **contents: read** to check out code, but they are only building and scanning locally