### PR TITLE
PF-2394 Add permissions to update image workflow

### DIFF
--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -60,7 +60,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
       pull-requests: read
 
     env:

--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -1,6 +1,8 @@
 # This GitHub Action calls workflow to update Docker image
 name: Call Update Image
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:
@@ -56,6 +58,10 @@ jobs:
 
   prepare-payload:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read
 
     env:
       jira-id: ""


### PR DESCRIPTION
This resets and adds permissions to the update image workflow. App repos will need to add **pull-request: read**, but this is already communicated

Testing

- **ci-call-update-image.yml** (with labels from PR): https://github.com/felleslosninger/plattform-test-app/actions/runs/25519844991/job/74901330799 ([workflow with branch](https://github.com/felleslosninger/plattform-test-app/actions/runs/25519844991/workflow))