### PR TITLE
PF-2365 Consolidate permissions reset in image build workflows

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -165,7 +165,7 @@ jobs:
   run-spring-boot-build:
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@PF-2365-reset-permissions-image-build-workflows
     permissions:
       contents: write
       packages: write
@@ -197,7 +197,7 @@ jobs:
   run-quarkus-build:
     needs: input-checks
     if: inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@PF-2365-reset-permissions-image-build-workflows
     permissions:
       contents: write
       id-token: write
@@ -225,7 +225,7 @@ jobs:
   run-docker-build:
     needs: input-checks
     if: inputs.application-type == 'docker'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@PF-2365-reset-permissions-image-build-workflows
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -165,7 +165,7 @@ jobs:
   run-spring-boot-build:
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@PF-2365-reset-permissions-image-build-workflows
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@main
     permissions:
       contents: write
       packages: write
@@ -197,7 +197,7 @@ jobs:
   run-quarkus-build:
     needs: input-checks
     if: inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@PF-2365-reset-permissions-image-build-workflows
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@main
     permissions:
       contents: write
       id-token: write
@@ -225,7 +225,7 @@ jobs:
   run-docker-build:
     needs: input-checks
     if: inputs.application-type == 'docker'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@PF-2365-reset-permissions-image-build-workflows
+    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@main
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -1,5 +1,7 @@
 name: Build/publish Docker image
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -1,5 +1,7 @@
 name: Build/publish Docker image
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -1,5 +1,7 @@
 name: Build and publish Docker image
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
We should reset permissions for all image build workflows so all workflows follow the same standard. Correct job permissions has already been added.

Testing:

- **ci-spring-boot-build-publish-image.yml**: https://github.com/felleslosninger/plattform-test-app/actions/runs/25521050384/job/74904900693 ([workflow with branch](https://github.com/felleslosninger/plattform-test-app/actions/runs/25521050384/workflow#L18))
- **ci-docker-build-publish-image.yml**: https://github.com/felleslosninger/plattform-test-app/actions/runs/25521288000 ([workflow with branch](https://github.com/felleslosninger/plattform-test-app/actions/runs/25521288000/workflow#L12))

I skipped Quarkus as it should behave exactly the same as the Spring Boot workflow.
