### PR TITLE
PF-2414 Sanitize and clean up main image build workflows

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -207,7 +207,7 @@ jobs:
   run-spring-boot-build:
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@PF-2414-sanitize-main-image-build-workflows
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@main
     permissions:
       contents: write
       packages: write
@@ -239,7 +239,7 @@ jobs:
   run-quarkus-build:
     needs: input-checks
     if: inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@PF-2414-sanitize-main-image-build-workflows
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@main
     permissions:
       contents: write
       id-token: write
@@ -267,7 +267,7 @@ jobs:
   run-docker-build:
     needs: input-checks
     if: inputs.application-type == 'docker'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@PF-2414-sanitize-main-image-build-workflows
+    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@main
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -207,7 +207,7 @@ jobs:
   run-spring-boot-build:
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@PF-2414-sanitize-main-image-build-workflows
     permissions:
       contents: write
       packages: write
@@ -239,7 +239,7 @@ jobs:
   run-quarkus-build:
     needs: input-checks
     if: inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-build-publish-image.yml@PF-2414-sanitize-main-image-build-workflows
     permissions:
       contents: write
       id-token: write
@@ -267,7 +267,7 @@ jobs:
   run-docker-build:
     needs: input-checks
     if: inputs.application-type == 'docker'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@PF-2414-sanitize-main-image-build-workflows
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -177,25 +177,31 @@ jobs:
     steps:
       - name: Check for supported application-type
         id: application-type-check
+        env:
+          APP_TYPE: ${{ inputs.application-type }}
         run: |
-          if [[ ${{ inputs.application-type }} != "spring-boot" && ${{ inputs.application-type }} != "quarkus" && ${{ inputs.application-type }} != "docker" ]]; then
+          if [[ "$APP_TYPE" != "spring-boot" && "$APP_TYPE" != "quarkus" && "$APP_TYPE" != "docker" ]]; then
             echo "Invalid application type. Supported types are: \`spring-boot\`, \`quarkus\` and \`docker\`" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
       - name: Set container registry
         id: set-container-registry
+        env:
+          CR_TYPE: ${{ inputs.cr-type }}
+          LIFECYCLE: ${{ inputs.lifecycle }}
         run: |
-          if [[ "${{ inputs.cr-type }}" == "ghcr" ]]; then
+          if [[ "$CR_TYPE" == "ghcr" ]]; then
             echo "container-registry=ghcr.io" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ inputs.lifecycle }}" == "deployment" ]]; then
+          elif [[ "$LIFECYCLE" == "deployment" ]]; then
             echo "sp-container-registry-client-id=AZURE_CLIENT_ID" >> "$GITHUB_OUTPUT"
             echo "container-registry=${{ vars.CR_DEPLOYMENT_URL }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ inputs.lifecycle }}" == "development" ]]; then
+          elif [[ "$LIFECYCLE" == "development" ]]; then
             echo "sp-container-registry-client-id=CR_DEV_USERNAME" >> "$GITHUB_OUTPUT"
             echo "container-registry=${{ vars.CR_DEV_URL }}" >> "$GITHUB_OUTPUT"
           else
             echo "Invalid lifecycle type. Supported types are: \`deployment\`, and \`development\`" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
 
   run-spring-boot-build:

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -217,7 +217,7 @@ jobs:
           skip-setup: true
 
       - name: Image signing
-        if: ${{ inputs.image-signing == true }}
+        if: inputs.image-signing == true
         uses: felleslosninger/github-workflows/.github/actions/image-signing@main
         with:
           image: ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }}

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -152,11 +152,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Build image
+        env:
+          APP_PATH: ${{ inputs.application-path }}
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+          ADD_TOKEN: ${{ inputs.add-git-package-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ inputs.add-git-package-token }}" = "true" ]; then
-            docker build --tag ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} --file docker/Dockerfile --build-arg GIT_PACKAGE_TOKEN=${{ secrets.GITHUB_TOKEN }} .
+          if [ "$ADD_TOKEN" = "true" ]; then
+            docker build --tag "$IMAGE_NAME:$IMAGE_TAG" --file docker/Dockerfile --build-arg GIT_PACKAGE_TOKEN="$GITHUB_TOKEN" .
           else
-            docker build --tag ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} --file ${{ inputs.application-path }}/Dockerfile .
+            docker build --tag "$IMAGE_NAME:$IMAGE_TAG" --file "$APP_PATH/Dockerfile" .
           fi
 
       - name: Run Trivy vulnerability scanner
@@ -182,13 +188,19 @@ jobs:
           acr-name: ${{ inputs.container-registry }}
 
       - name: "Push image"
-        run: docker push ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }}
+        env:
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+        run: docker push "$IMAGE_NAME:$IMAGE_TAG"
 
       - name: Set image digest
         id: set-image-digest
+        env:
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
         run: |
           image_digest=$(docker inspect \
-            --format='{{.RepoDigests}}' ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
+            --format='{{.RepoDigests}}' "$IMAGE_NAME:$IMAGE_TAG" \
             | cut -d '@' -f 2 \
             | cut -d ']' -f 1)
           echo "image-digest=$image_digest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -188,13 +188,13 @@ jobs:
           cache: maven
           cache-dependency-path: ${{ inputs.cache-path }}
           server-id: github
-          server-username: MAVEN_USER
-          server-password: MAVEN_PASSWORD
+          server-username: GH_PACKAGES_READ_USER
+          server-password: GH_PACKAGES_READ_PAT
 
       - name: Maven update version used in application.yaml
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
         run: mvn versions:set -B -DnewVersion="$IMAGE_TAG"
 
@@ -217,8 +217,8 @@ jobs:
       - name: Build native image with Maven/Quarkus
         if: inputs.native == true
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
           IMAGE_PACK: ${{ inputs.image-pack }}
@@ -235,16 +235,16 @@ jobs:
             --env BP_MAVEN_POM_FILE="./pom.xml" \
             --env BP_NATIVE_IMAGE="true" \
             --env LANG="C.UTF-8" \
-            --env MAVEN_USER="$MAVEN_USER" \
-            --env MAVEN_PASSWORD="$MAVEN_PASSWORD" \
+            --env GH_PACKAGES_READ_USER="$GH_PACKAGES_READ_USER" \
+            --env GH_PACKAGES_READ_PAT="$GH_PACKAGES_READ_PAT" \
             --creation-time now
 
       # Build JVM image with Paketo buildpacks
       - name: Build image with Maven/Quarkus
         if: inputs.native == false
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
           IMAGE_PACK: ${{ inputs.image-pack }}
@@ -259,8 +259,8 @@ jobs:
             --volume "${HOME}/.m2:/home/cnb/.m2:rw" \
             --env BP_JVM_VERSION="$JAVA_VERSION" \
             --env BP_MAVEN_POM_FILE="./pom.xml" \
-            --env MAVEN_USER="$MAVEN_USER" \
-            --env MAVEN_PASSWORD="$MAVEN_PASSWORD" \
+            --env GH_PACKAGES_READ_USER="$GH_PACKAGES_READ_USER" \
+            --env GH_PACKAGES_READ_PAT="$GH_PACKAGES_READ_PAT" \
             --creation-time now
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -310,7 +310,7 @@ jobs:
           skip-setup: true
 
       - name: Image signing
-        if: ${{ inputs.image-signing == true }}
+        if: inputs.image-signing == true
         uses: felleslosninger/github-workflows/.github/actions/image-signing@main
         with:
           image: "${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }}"

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -162,9 +162,6 @@ jobs:
       image-tag: ${{ steps.image-metadata.outputs.image-tag }}
       image-digest: ${{ steps.set-image-digest.outputs.image-digest }}
 
-    env:
-      DOCKLE_HOST: "unix:///var/run/docker.sock"
-
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -195,9 +195,12 @@ jobs:
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        run: mvn versions:set -B -DnewVersion="${{ steps.image-metadata.outputs.image-tag }}"
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+        run: mvn versions:set -B -DnewVersion="$IMAGE_TAG"
 
       - name: Install pack
+        env:
+          PACK_VERSION: 0.39.1
         run: |
           #!/usr/bin/env bash
           set -euo pipefail
@@ -209,8 +212,6 @@ jobs:
             --silent \
             "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
           | sudo tar -C /usr/local/bin --no-same-owner -xzv pack
-        env:
-          PACK_VERSION: 0.39.1
 
       # Build GraalVM native image with Paketo buildpacks
       - name: Build native image with Maven/Quarkus
@@ -218,19 +219,24 @@ jobs:
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+          IMAGE_PACK: ${{ inputs.image-pack }}
+          IMAGE_PACK_TAG: ${{ inputs.image-pack-tag }}
+          JAVA_VERSION: ${{ inputs.java-version }}
         run: |
-          pack build ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
+          pack build "$IMAGE_NAME:$IMAGE_TAG" \
             --path . \
             --buildpack docker://paketobuildpacks/quarkus \
             --buildpack docker://paketobuildpacks/java-native-image \
-            --builder paketobuildpacks/${{ inputs.image-pack }}:${{ inputs.image-pack-tag }} \
+            --builder "paketobuildpacks/$IMAGE_PACK:$IMAGE_PACK_TAG" \
             --volume "${HOME}/.m2:/home/cnb/.m2:rw" \
-            --env BP_JVM_VERSION="${{ inputs.java-version }}" \
+            --env BP_JVM_VERSION="$JAVA_VERSION" \
             --env BP_MAVEN_POM_FILE="./pom.xml" \
             --env BP_NATIVE_IMAGE="true" \
             --env LANG="C.UTF-8" \
-            --env MAVEN_USER="${{ env.MAVEN_USER }}" \
-            --env MAVEN_PASSWORD="${{ env.MAVEN_PASSWORD }}" \
+            --env MAVEN_USER="$MAVEN_USER" \
+            --env MAVEN_PASSWORD="$MAVEN_PASSWORD" \
             --creation-time now
 
       # Build JVM image with Paketo buildpacks
@@ -239,17 +245,22 @@ jobs:
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+          IMAGE_PACK: ${{ inputs.image-pack }}
+          IMAGE_PACK_TAG: ${{ inputs.image-pack-tag }}
+          JAVA_VERSION: ${{ inputs.java-version }}
         run: |
-          pack build ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
+          pack build "$IMAGE_NAME:$IMAGE_TAG" \
             --path . \
             --buildpack docker://paketobuildpacks/quarkus \
             --buildpack docker://paketobuildpacks/java \
-            --builder paketobuildpacks/${{ inputs.image-pack }}:${{ inputs.image-pack-tag }} \
+            --builder "paketobuildpacks/$IMAGE_PACK:$IMAGE_PACK_TAG" \
             --volume "${HOME}/.m2:/home/cnb/.m2:rw" \
-            --env BP_JVM_VERSION="${{ inputs.java-version }}" \
+            --env BP_JVM_VERSION="$JAVA_VERSION" \
             --env BP_MAVEN_POM_FILE="./pom.xml" \
-            --env MAVEN_USER="${{ env.MAVEN_USER }}" \
-            --env MAVEN_PASSWORD="${{ env.MAVEN_PASSWORD }}" \
+            --env MAVEN_USER="$MAVEN_USER" \
+            --env MAVEN_PASSWORD="$MAVEN_PASSWORD" \
             --creation-time now
 
       - name: Run Trivy vulnerability scanner
@@ -273,13 +284,19 @@ jobs:
           acr-name: ${{ inputs.container-registry }}
 
       - name: Push image
-        run: docker push ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }}
+        env:
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+        run: docker push "$IMAGE_NAME:$IMAGE_TAG"
 
       - name: Set image digest
         id: set-image-digest
+        env:
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
         run: |
           image_digest=$(docker inspect \
-            --format='{{.RepoDigests}}' ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
+            --format='{{.RepoDigests}}' "$IMAGE_NAME:$IMAGE_TAG" \
             | cut -d '@' -f 2 \
             | cut -d ']' -f 1)
           echo "image-digest=$image_digest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -211,9 +211,11 @@ jobs:
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          UPDATE_VERSIONS: ${{ inputs.update-versions }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
         run: |
-          if [ "${{ inputs.update-versions }}" == "true" ]; then
-            mvn versions:set -B -DnewVersion="${{ steps.image-metadata.outputs.image-tag }}"
+          if [ "$UPDATE_VERSIONS" == "true" ]; then
+            mvn versions:set -B -DnewVersion="$IMAGE_TAG"
             echo "- \`mvn versions\` was executed" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- \`mvn versions\` was not executed" >> "$GITHUB_STEP_SUMMARY"
@@ -224,11 +226,16 @@ jobs:
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MODULE_NAME: ${{ inputs.module-name }}
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+          IMAGE_PACK: ${{ inputs.image-pack }}
+          IMAGE_PACK_TAG: ${{ inputs.image-pack-tag }}
         run: |
           mvn install -B spring-boot:build-image \
-            -pl ${{ inputs.module-name }} -am  \
-            -Dspring-boot.build-image.imageName=${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
-            -Dspring-boot.build-image.builder=paketobuildpacks/${{ inputs.image-pack }}:${{ inputs.image-pack-tag }} \
+            -pl "$MODULE_NAME" -am  \
+            -Dspring-boot.build-image.imageName="$IMAGE_NAME:$IMAGE_TAG" \
+            -Dspring-boot.build-image.builder="paketobuildpacks/$IMAGE_PACK:$IMAGE_PACK_TAG" \
             -Dspring-boot.build-image.createdDate=now
 
       - name: Build image with Maven/Spring Boot (application-path)
@@ -236,11 +243,16 @@ jobs:
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          APP_PATH: ${{ inputs.application-path }}
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+          IMAGE_PACK: ${{ inputs.image-pack }}
+          IMAGE_PACK_TAG: ${{ inputs.image-pack-tag }}
         run: |
           mvn -B spring-boot:build-image \
-            --file ${{ inputs.application-path }}pom.xml \
-            -Dspring-boot.build-image.imageName=${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
-            -Dspring-boot.build-image.builder=paketobuildpacks/${{ inputs.image-pack }}:${{ inputs.image-pack-tag }} \
+            --file "${APP_PATH}pom.xml" \
+            -Dspring-boot.build-image.imageName="$IMAGE_NAME:$IMAGE_TAG" \
+            -Dspring-boot.build-image.builder="paketobuildpacks/$IMAGE_PACK:$IMAGE_PACK_TAG" \
             -Dspring-boot.build-image.createdDate=now
 
       - name: Run Trivy vulnerability scanner
@@ -275,13 +287,19 @@ jobs:
           acr-name: ${{ inputs.container-registry }}
 
       - name: Push image
-        run: docker push ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }}
+        env:
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+        run: docker push "$IMAGE_NAME:$IMAGE_TAG"
 
       - name: Set image digest
         id: set-image-digest
+        env:
+          IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
+          IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
         run: |
           image_digest=$(docker inspect \
-            --format='{{.RepoDigests}}' ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
+            --format='{{.RepoDigests}}' "$IMAGE_NAME:$IMAGE_TAG" \
             | cut -d '@' -f 2 \
             | cut -d ']' -f 1)
           echo "image-digest=$image_digest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -316,7 +316,7 @@ jobs:
           skip-setup: true
 
       - name: Image signing
-        if: ${{ inputs.image-signing == true }}
+        if: inputs.image-signing == true
         uses: felleslosninger/github-workflows/.github/actions/image-signing@main
         with:
           image: ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }}

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -204,13 +204,13 @@ jobs:
           cache: maven
           cache-dependency-path: ${{ inputs.cache-path }}
           server-id: github
-          server-username: MAVEN_USER
-          server-password: MAVEN_PASSWORD
+          server-username: GH_PACKAGES_READ_USER
+          server-password: GH_PACKAGES_READ_PAT
 
       - name: Maven update version used in application.yaml
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           UPDATE_VERSIONS: ${{ inputs.update-versions }}
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
         run: |
@@ -224,8 +224,8 @@ jobs:
       - name: Build image with Maven/Spring Boot (module-name)
         if: inputs.module-name != ''
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           MODULE_NAME: ${{ inputs.module-name }}
           IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
@@ -241,8 +241,8 @@ jobs:
       - name: Build image with Maven/Spring Boot (application-path)
         if: inputs.module-name == ''
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           APP_PATH: ${{ inputs.application-path }}
           IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}


### PR DESCRIPTION
This PR sanitizes inputs in all image build workflows that are used to build images on app repository **main** commits. [Official docs on this](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks).

This includes

- [Entrypoint workflow](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-build-publish-image.yml)
- [Docker workflow](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-docker-build-publish-image.yml)
- [Quarkus workflow](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-quarkus-build-publish-image.yml)
- [Spring Boot workflow](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-spring-boot-build-publish-image.yml)

This initially was also meant to include the [dev build/publish workflow](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/misc-publish-dev-docker.yml), but this is already immune to injection via inputs in bash, or JSON.

---

Other changes

- Migrate to the best practice `GH_PACKAGES_READ_USER` and `GH_PACKAGES_READ_PAT` instead of `MAVEN_USER` and `MAVEN_PASSWORD`
- Remove `DOCKLE_HOST` that was previously used for the [Azure container scan action](https://github.com/Azure/container-scan) which is deprectaed. We have migrated to Trivy
- Remove `${{ }}` from `if` statements as they are unnecessary, and it is best practice to evaluate directly

---

Testing:

Read https://github.com/felleslosninger/platform/blob/main/docs/pipeline/how-to/pipeline-testing.md#image-builds-on-main-production-images on how to test. 

- Docker: https://github.com/felleslosninger/plattform-test-app/actions/runs/26499985565 - seems to work as intended. 
- Quarkus: https://github.com/felleslosninger/plattform-test-app-quarkus/actions/runs/26499808057 - seems to work as intended.
- Spring Boot: https://github.com/felleslosninger/plattform-test-app/actions/runs/26499663256 - seems to work as intended.

Another round after latest changes

- Docker: https://github.com/felleslosninger/plattform-test-app/actions/runs/27102176106
- Spring Boot: https://github.com/felleslosninger/plattform-test-app/actions/runs/27102170654
- Quarkus: https://github.com/felleslosninger/plattform-test-app-quarkus/actions/runs/27102361118