### PR TITLE
PF-2416 Sanitize and clean up update image workflow

### DIFF
--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -99,14 +99,6 @@ jobs:
       jira-id: ""
 
     steps:
-      - name: Check important image inputs
-        if: |
-          inputs.image-version == '' ||
-          inputs.image-digest == ''
-        run: |
-          echo "One or more empty image inputs detected. Exiting" >> "$GITHUB_STEP_SUMMARY"
-          exit 1
-
       - name: Set container registry
         id: set-container-registry
         env:

--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -109,13 +109,16 @@ jobs:
 
       - name: Set container registry
         id: set-container-registry
+        env:
+          LIFECYCLE: ${{ inputs.lifecycle }}
         run: |
-          if [[ "${{ inputs.lifecycle }}" == "deployment" ]]; then
+          if [[ "$LIFECYCLE" == "deployment" ]]; then
             echo "container-registry=${{ vars.CR_DEPLOYMENT_URL }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ inputs.lifecycle }}" == "development" ]]; then
+          elif [[ "$LIFECYCLE" == "development" ]]; then
             echo "container-registry=${{ vars.CR_DEV_URL }}" >> "$GITHUB_OUTPUT"
           else
             echo "Invalid lifecycle type. Supported types are: \`deployment\`, and \`development\`" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
 
       - name: Get Labels
@@ -137,8 +140,7 @@ jobs:
         env:
           GIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          JIID=$(echo "$GIT_MSG" | head -1 |
-          grep -Eo '^([a-zA-Z]{2,6}-[0-9]+)') || JIID=''
+          JIID=$(echo "$GIT_MSG" | head -1 | grep -Eo '^([a-zA-Z]{2,6}-[0-9]+)') || JIID=''
           echo "jira-id=$JIID" >> "$GITHUB_ENV"
 
       - name: Check Dependabot
@@ -149,46 +151,46 @@ jobs:
       - name: Set Dependabot As Jira ID
         id: output-dependabot
         if: |
-          steps.find-jira-id.outputs.match == '' &&
+          env.jira-id == '' &&
           steps.check-dependabot.outputs.dependabot == 'true'
         run: echo "jira-id=Dependabot" >> "$GITHUB_ENV"
 
       - name: Set Author Username, Name, and Email
         id: set-author-info
+        env:
+          PUSHER_NAME: ${{ github.event.pusher.name }}
+          PUSHER_EMAIL: ${{ github.event.pusher.email }}
         run: |
-          actor_name="${{ github.event.pusher.name }}"
-          actor_email="${{ github.event.pusher.name }}"
-
-          # Check if actor_name is null or empty
-          if [ -z "$actor_name" ]; then
-            actor_name="github-actions[bot]"  # Set default value
-          fi
-
-          # Check if actor_email is null or empty
-          if [ -z "$actor_email" ]; then
-            actor_email="41898282+github-actions[bot]@users.noreply.github.com"  # Set default value
-          fi
+          actor_name="${PUSHER_NAME:-github-actions[bot]}"
+          actor_email="${PUSHER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
 
           {
-            echo "author-username=${{ github.event.pusher.name }}"
-            echo "author-email=${actor_email}@users.noreply.github.com"
-            echo "author-name=${actor_name}"
+            echo "author-username=$actor_name"
+            echo "author-email=$actor_email"
+            echo "author-name=$actor_name"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set Outputs
         id: set-outputs
+        env:
+          IMAGE_NAME: ${{ inputs.image-name }}
+          IMAGE_VERSION: ${{ inputs.image-version }}
+          IMAGE_DIGEST: ${{ inputs.image-digest }}
+          CR_REGISTRY: ${{ steps.set-container-registry.outputs.container-registry }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
         run: |
           {
             echo "author-email=${{ steps.set-author-info.outputs.author-email }}"
             echo "author-name=${{ steps.set-author-info.outputs.author-name }}"
             echo "author-username=${{ steps.set-author-info.outputs.author-username }}"
             echo "dependabot=${{ steps.check-dependabot.outputs.dependabot }}"
-            echo "image-name=${{ inputs.image-name }}"
-            echo "image=${{ steps.set-container-registry.outputs.container-registry }}/${{ inputs.image-name }}:${{ inputs.image-version }}@${{ inputs.image-digest }}"
+            echo "image-name=$IMAGE_NAME"
+            echo "image=$CR_REGISTRY/$IMAGE_NAME:$IMAGE_VERSION@$IMAGE_DIGEST"
             echo "pr-labels=${{ steps.set-pr-labels-and-number.outputs.pr-labels }}"
             echo "pr-number=${{ steps.set-pr-labels-and-number.outputs.pr-number }}"
-            echo "repository=${{ github.repository }}"
-            echo "sha=${{ github.sha }}"
+            echo "repository=$REPO"
+            echo "sha=$SHA"
           } >> "$GITHUB_OUTPUT"
 
       - name: Generate Token
@@ -202,21 +204,32 @@ jobs:
 
       - name: Log Outputs
         id: log-outputs
+        env:
+          AUTHOR_EMAIL: ${{ steps.set-author-info.outputs.author-email }}
+          AUTHOR_NAME: ${{ steps.set-author-info.outputs.author-name }}
+          AUTHOR_USERNAME: ${{ steps.set-author-info.outputs.author-username }}
+          DEPENDABOT: ${{ steps.set-outputs.outputs.dependabot }}
+          IMAGE_NAME: ${{ steps.set-outputs.outputs.image-name }}
+          IMAGE_FULL: ${{ steps.set-outputs.outputs.image }}
+          PR_LABELS: ${{ steps.set-outputs.outputs.pr-labels }}
+          PR_NUMBER: ${{ steps.set-outputs.outputs.pr-number }}
+          REPOSITORY: ${{ steps.set-outputs.outputs.repository }}
+          SHA: ${{ steps.set-outputs.outputs.sha }}
         run: |
           {
             echo "# Outputs"
             echo "| Key                     | Value                                                 |"
             echo "| ----------------------- | ----------------------------------------------------- |"
-            echo "| author-email            | ${{ steps.set-author-info.outputs.author-email }}     |"
-            echo "| author-name             | ${{ steps.set-author-info.outputs.author-name }}      |"
-            echo "| author-username         | ${{ steps.set-author-info.outputs.author-username }}  |"
-            echo "| dependabot              | ${{ steps.set-outputs.outputs.dependabot }}           |"
-            echo "| image-name              | ${{ steps.set-outputs.outputs.image-name }}           |"
-            echo "| image                   | ${{ steps.set-outputs.outputs.image }}                |"
-            echo "| pr-labels               | ${{ steps.set-outputs.outputs.pr-labels }}            |"
-            echo "| pr-number               | ${{ steps.set-outputs.outputs.pr-number }}            |"
-            echo "| repository              | ${{ steps.set-outputs.outputs.repository }}           |"
-            echo "| sha                     | ${{ steps.set-outputs.outputs.sha }}                  |"
+            echo "| author-email            | $AUTHOR_EMAIL                                         |"
+            echo "| author-name             | $AUTHOR_NAME                                          |"
+            echo "| author-username         | $AUTHOR_USERNAME                                      |"
+            echo "| dependabot              | $DEPENDABOT                                           |"
+            echo "| image-name              | $IMAGE_NAME                                           |"
+            echo "| image                   | $IMAGE_FULL                                           |"
+            echo "| pr-labels               | $PR_LABELS                                            |"
+            echo "| pr-number               | $PR_NUMBER                                            |"
+            echo "| repository              | $REPOSITORY                                           |"
+            echo "| sha                     | $SHA                                                  |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Call Dispatch To Start Promotion
@@ -227,25 +240,25 @@ jobs:
           repository: "felleslosninger/${{ inputs.kubernetes-repo }}"
           # Wraps everything inside 'data' to get around Github's limit:
           # The maximum number of top-level properties in client_payload is 10.
-          client-payload: |-
+          client-payload: >
             {
               "data": {
-                "application-name": "${{ inputs.application-name }}",
-                "author-email": "${{ steps.set-outputs.outputs.author-email }}",
-                "author-name": "${{ steps.set-outputs.outputs.author-name }}",
-                "author-username": "${{ steps.set-outputs.outputs.author-username }}",
-                "deployment-environment": "${{ inputs.deployment-environment }}",
-                "image-digest": "${{ inputs.image-digest }}",
-                "image-name": "${{ steps.set-outputs.outputs.image-name }}",
-                "image-version": "${{ inputs.image-version }}",
-                "image": "${{ steps.set-container-registry.outputs.container-registry }}/${{ steps.set-outputs.outputs.image-name }}:${{inputs.image-version}}@${{inputs.image-digest}}",
-                "jira-id": "${{ env.jira-id }}",
-                "kubernetes-repo": "${{ inputs.kubernetes-repo }}",
-                "pr-labels": "${{ steps.set-outputs.outputs.pr-labels }}",
-                "pr-number": "${{ steps.set-outputs.outputs.pr-number }}",
-                "product-name": "${{ inputs.product-name }}",
-                "repository": "${{ steps.set-outputs.outputs.repository }}",
-                "sha": "${{ steps.set-outputs.outputs.sha }}",
-                "kustomize-version": "${{ inputs.kustomize-version }}"
+                "application-name": ${{ toJson(inputs.application-name) }},
+                "author-email": ${{ toJson(steps.set-outputs.outputs.author-email) }},
+                "author-name": ${{ toJson(steps.set-outputs.outputs.author-name) }},
+                "author-username": ${{ toJson(steps.set-outputs.outputs.author-username) }},
+                "deployment-environment": ${{ toJson(inputs.deployment-environment) }},
+                "image-digest": ${{ toJson(inputs.image-digest) }},
+                "image-name": ${{ toJson(steps.set-outputs.outputs.image-name) }},
+                "image-version": ${{ toJson(inputs.image-version) }},
+                "image": ${{ toJson(steps.set-outputs.outputs.image) }},
+                "jira-id": ${{ toJson(env.jira-id) }},
+                "kubernetes-repo": ${{ toJson(inputs.kubernetes-repo) }},
+                "pr-labels": ${{ toJson(steps.set-outputs.outputs.pr-labels) }},
+                "pr-number": ${{ toJson(steps.set-outputs.outputs.pr-number) }},
+                "product-name": ${{ toJson(inputs.product-name) }},
+                "repository": ${{ toJson(steps.set-outputs.outputs.repository) }},
+                "sha": ${{ toJson(steps.set-outputs.outputs.sha) }},
+                "kustomize-version": ${{ toJson(inputs.kustomize-version) }}
               }
             }

--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -99,6 +99,14 @@ jobs:
       jira-id: ""
 
     steps:
+      - name: Check important image inputs
+        if: |
+          inputs.image-version == '' ||
+          inputs.image-digest == ''
+        run: |
+          echo "One or more empty image inputs detected. Exiting" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
       - name: Set container registry
         id: set-container-registry
         env:

--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -151,10 +151,15 @@ jobs:
         id: set-author-info
         env:
           PUSHER_NAME: ${{ github.event.pusher.name }}
-          PUSHER_EMAIL: ${{ github.event.pusher.email }}
         run: |
-          actor_name="${PUSHER_NAME:-github-actions[bot]}"
-          actor_email="${PUSHER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+          # Set bot default if actor name is empty
+          if [ -z "$PUSHER_NAME" ]; then
+            actor_name="github-actions[bot]"
+            actor_email="41898282+github-actions[bot]@users.noreply.github.com"
+          else
+            actor_name="$PUSHER_NAME"
+            actor_email="$PUSHER_NAME@users.noreply.github.com"
+          fi
 
           {
             echo "author-username=$actor_name"


### PR DESCRIPTION
This PR sanitizes inputs/json in the update image workflow that triggers after an image is built and pushed to ACR (**main** commit). [Official docs on this](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks).

This includes

- [Update image workflow](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-call-update-image.yml)

---

Other changes:

- The lifecycle step check now properly fails the pipeline if the lifecycle is not supported
- The `Set Dependabot As Jira ID` step checked `steps.find-jira-id.outputs.match == ''`, but the `find-jira-id` step never creates that output 🤷 This means that condition was always evaluating to true. It is now removed so the logic makes sense
- The `Set Author Username, Name, and Email` step is simplified with backwards compatibility (we still use GitHub email for everything)

PS! Initially, I removed the input validation for `image-digest` and `image-name` since they are required inputs, but apparently an empty input is still considered a valid input, so we actually need this check (ref: https://github.com/actions/runner/issues/1070). It is insane that it works this way...

---

Read https://github.com/felleslosninger/platform/blob/main/docs/pipeline/how-to/pipeline-testing.md#cd-repo-image-update on how to test. 

Test runs:

- Update image: https://github.com/felleslosninger/plattform-test-app/actions/runs/26495570549 - seem to work as intended. 
- Update image (latest version): https://github.com/felleslosninger/plattform-test-app/actions/runs/27020891651/job/79748810300 (looks good)