### PR TITLE
PF-2386 Support library repositories for PR checks

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -55,8 +55,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Start Trivy vulnerability scan
+    - name: Start Trivy vulnerability scan ($SCAN_TYPE)
       shell: bash
+      env:
+        SCAN_TYPE: ${{ inputs.scan-type }}
       run: |
         echo "### Trivy vulnerability scan" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -3,7 +3,7 @@
 # 2. Builds and runs application from root pom with mvn lifecycle chosen in inputs (default: test).
 # 3. Scans libraries with Trivy FS scan
 # 4. Builds image with using paketo buildpacks. (if enable-image-build is true)
-# 5. Scans image with Trivy image scan (if inputs.enable-image-build == true && inputs.trivy-library-disable-scan == false)
+# 5. Scans image with Trivy image scan for containerized/image-build workflows (gated by enable-image-build and application-type; OS scanning is separately controlled by trivy-os-disable-scan)
 # 6. Auto-merges Dependabot PRs (optional)
 
 # If you are building a library project, you can set enable-image-build to false which will skip steps 4->.

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -187,17 +187,6 @@ jobs:
           server-username: MAVEN_USER
           server-password: MAVEN_PASSWORD
 
-      - name: Run Trivy vulnerability scanner
-        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
-        if: inputs.trivy-library-disable-scan == false
-        with:
-          scan-type: "fs"
-          application-path: ${{ inputs.application-path }}
-          library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
-          library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
-          library-severity: ${{ inputs.trivy-library-severity }}
-          trivy-version: ${{ inputs.trivy-version }}
-
       - name: Run mvn ${{ inputs.maven-lifecycle }}
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
@@ -213,6 +202,17 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Run Trivy vulnerability scanner
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
+        if: inputs.trivy-library-disable-scan == false
+        with:
+          scan-type: "fs"
+          application-path: ${{ inputs.application-path }}
+          library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+          library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+          library-severity: ${{ inputs.trivy-library-severity }}
+          trivy-version: ${{ inputs.trivy-version }}
 
       - name: Upload artifact
         if: |

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -1,10 +1,17 @@
+# This is the golden path for PRs towards main branch. This workflow handles both mvn library builds and containerized builds. 
 # 1. Verifies PR title
-# 2. Builds and runs application
-# 3. Scans image with Trivy
-# 4. Auto-merges Dependabot PRs (optional)
+# 2. Builds and runs application from root pom with mvn lifecycle chosen in inputs (default: test).
+# 3. Scans libraries with Trivy FS scan
+# 4. Builds image with using paketo buildpacks. (if enable-image-build is true)
+# 5. Scans image with Trivy image scan (if inputs.enable-image-build == true && inputs.trivy-library-disable-scan == false)
+# 6. Auto-merges Dependabot PRs (optional)
 
-#This workflow is the golden path for PRs towards main branch. This workflow handles both mvn library builds and containerized builds. 
-#First, it does mvn build with chosen lifecycle followed by a trivy fs scan. Then, it can build and scan container images if configured to do so with enable-image-build. 
+# If you are building a library project, you can set enable-image-build to false which will skip steps 4->.
+
+
+#If you have a multi module project, the mvn lifecycle will first be executed in the root of the project, then the container build will be executed for the module specified with module-name input. 
+#If your multi module project has multiple bootable modules you want in separate containers, you can reference this workflow multiple times with different module-name inputs.
+#For non-containerized applications, you can set enable-image-build to false to skip the image build and image scan steps. This will allow you to use this workflow for library projects as well.
 
 
 name: PR Checks
@@ -94,7 +101,7 @@ on:
         required: false
         type: string
       module-name:
-        description: 'Name of the module to build and scan (for multi-module projects)'
+        description: 'Only for container builds, the module in multi module projects which is bootable inside the container.'
         type: string
         required: false
         default: ''

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -6,12 +6,12 @@
 # 5. Scans image with Trivy image scan for containerized/image-build workflows (gated by enable-image-build and application-type; OS scanning is separately controlled by trivy-os-disable-scan)
 # 6. Auto-merges Dependabot PRs (optional)
 
-# If you are building a library project, you can set enable-image-build to false which will skip steps 4->.
+# If you are building a library project, you can set enable-image-build to false to skip the image build and image scan steps.
 
 
-#If you have a multi module project, the mvn lifecycle will first be executed in the root of the project, then the container build will be executed for the module specified with module-name input. 
-#If your multi module project has multiple bootable modules you want in separate containers, you can reference this workflow multiple times with different module-name inputs.
-#For non-containerized applications, you can set enable-image-build to false to skip the image build and image scan steps. This will allow you to use this workflow for library projects as well.
+# If you have a multi-module project, the mvn lifecycle will first be executed in the root of the project, then the container build will be executed for the module specified with the module-name input.
+# If your multi-module project has multiple bootable modules that you want in separate containers, you can reference this workflow multiple times with different module-name inputs.
+# For non-containerized applications, you can set enable-image-build to false to skip the image build and image scan steps. This will allow you to use this workflow for library projects as well.
 
 
 name: PR Checks

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -187,6 +187,17 @@ jobs:
           server-username: MAVEN_USER
           server-password: MAVEN_PASSWORD
 
+      - name: Run Trivy vulnerability scanner
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
+        if: inputs.trivy-library-disable-scan == false
+        with:
+          scan-type: "fs"
+          application-path: ${{ inputs.application-path }}
+          library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+          library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+          library-severity: ${{ inputs.trivy-library-severity }}
+          trivy-version: ${{ inputs.trivy-version }}
+
       - name: Run mvn ${{ inputs.maven-lifecycle }}
         env:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
@@ -202,17 +213,6 @@ jobs:
               exit 1
               ;;
           esac
-
-      - name: Run Trivy vulnerability scanner
-        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
-        if: inputs.trivy-library-disable-scan == false
-        with:
-          scan-type: "fs"
-          application-path: ${{ inputs.application-path }}
-          library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
-          library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
-          library-severity: ${{ inputs.trivy-library-severity }}
-          trivy-version: ${{ inputs.trivy-version }}
 
       - name: Upload artifact
         if: |

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -3,6 +3,10 @@
 # 3. Scans image with Trivy
 # 4. Auto-merges Dependabot PRs (optional)
 
+#This workflow is the golden path for PRs towards main branch. This workflow handles both mvn library builds and containerized builds. 
+#First, it does mvn build with chosen lifecycle followed by a trivy fs scan. Then, it can build and scan container images if configured to do so with enable-image-build. 
+
+
 name: PR Checks
 
 permissions: {}
@@ -10,6 +14,10 @@ permissions: {}
 on:
   workflow_call:
     inputs:
+      enable-image-build:
+        type: boolean
+        default: true
+        description: Set to false to skip the image build and image scan steps.
       application-type:
         type: string
         required: true
@@ -17,9 +25,6 @@ on:
         type: boolean
         default: false
       enable-pr-title-verify:
-        type: boolean
-        default: true
-      enable-trivy-image-scan:
         type: boolean
         default: true
       java-version:
@@ -128,6 +133,7 @@ on:
         type: string
         required: false
         default: ''
+      
 
 jobs:
   verify-pull-request-title:
@@ -197,6 +203,17 @@ jobs:
               ;;
           esac
 
+      - name: Run Trivy vulnerability scanner
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
+        if: inputs.trivy-library-disable-scan == false
+        with:
+          scan-type: "fs"
+          application-path: ${{ inputs.application-path }}
+          library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+          library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+          library-severity: ${{ inputs.trivy-library-severity }}
+          trivy-version: ${{ inputs.trivy-version }}
+
       - name: Upload artifact
         if: |
           !cancelled() &&
@@ -208,8 +225,9 @@ jobs:
 
   call-spring-boot-container-scan:
     name: Call Spring Boot container scan
+    needs: build-and-test-java
     if: |
-      inputs.enable-trivy-image-scan == true &&
+      inputs.enable-image-build == true &&
       inputs.application-type == 'spring-boot'
     uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
     permissions:
@@ -232,8 +250,9 @@ jobs:
 
   call-quarkus-container-scan:
     name: Call Quarkus container scan
+    needs: build-and-test-java
     if: |
-      inputs.enable-trivy-image-scan == true &&
+      inputs.enable-image-build == true &&
       inputs.application-type == 'quarkus'
     uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
     permissions:

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -226,13 +226,13 @@ jobs:
           cache: maven
           cache-dependency-path: ${{ inputs.cache-path }}
           server-id: github
-          server-username: MAVEN_USER
-          server-password: MAVEN_PASSWORD
+          server-username: GH_PACKAGES_READ_USER
+          server-password: GH_PACKAGES_READ_PAT
 
       - name: Run mvn ${{ inputs.maven-lifecycle }}
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
         run: |
           LIFECYCLE="${{ inputs.maven-lifecycle }}"
           case "$LIFECYCLE" in

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -127,10 +127,18 @@ on:
         required: false
         type: string
       maven-lifecycle:
-        description: 'Maven lifecycle phase (test, package, verify, install)'
+        description: Maven lifecycle phase (test, package, verify, install)
         type: string
         required: false
-        default: 'test'
+        default: "test"
+      maven-clean:
+        description: Run the clean phase before the lifecycle phase
+        type: boolean
+        default: false
+      maven-update-snapshots:
+        description: Force update of SNAPSHOT dependencies (-U)
+        type: boolean
+        default: false
       application-path:
         description: 'Path to the application to scan with Trivy. Default is root of the repository, but can be set to a specific module in multi-module projects.'
         default: "./"
@@ -235,15 +243,31 @@ jobs:
           GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
         run: |
           LIFECYCLE="${{ inputs.maven-lifecycle }}"
+
           case "$LIFECYCLE" in
             test|package|verify|install)
-              mvn -B "$LIFECYCLE"
               ;;
             *)
               echo "Invalid Maven lifecycle: $LIFECYCLE"
               exit 1
               ;;
           esac
+
+          # Build the Maven command dynamically
+          ARGS=("-B")
+
+          if [ "${{ inputs.maven-clean }}" == "true" ]; then
+            ARGS+=("clean")
+          fi
+
+          ARGS+=("$LIFECYCLE")
+
+          if [ "${{ inputs.maven-update-snapshots }}" == "true" ]; then
+            ARGS+=("--update-snapshots")
+          fi
+
+          # Execute the Maven command
+          mvn "${ARGS[@]}"
 
       - name: Run Trivy vulnerability scanner
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -295,7 +295,7 @@ jobs:
     if: |
       inputs.enable-image-build == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2386-harmonize-pipeling
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
     permissions:
       contents: read
     with:
@@ -320,7 +320,7 @@ jobs:
     if: |
       inputs.enable-image-build == true &&
       inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@PF-2386-harmonize-pipeling
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
     permissions:
       contents: read
     with:

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -271,7 +271,7 @@ jobs:
     if: |
       inputs.enable-image-build == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2386-harmonize-pipeling
     permissions:
       contents: read
     with:
@@ -296,7 +296,7 @@ jobs:
     if: |
       inputs.enable-image-build == true &&
       inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@PF-2386-harmonize-pipeling
     permissions:
       contents: read
     with:

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -1,18 +1,39 @@
-# This is the golden path for PRs towards main branch. This workflow handles both mvn library builds and containerized builds. 
-# 1. Verifies PR title
-# 2. Builds and runs application from root pom with mvn lifecycle chosen in inputs (default: test).
-# 3. Scans libraries with Trivy FS scan
-# 4. Builds image with using paketo buildpacks. (if enable-image-build is true)
-# 5. Scans image with Trivy image scan for containerized/image-build workflows (gated by enable-image-build and application-type; OS scanning is separately controlled by trivy-os-disable-scan)
-# 6. Auto-merges Dependabot PRs (optional)
-
-# If you are building a library project, you can set enable-image-build to false to skip the image build and image scan steps.
-
-
-# If you have a multi-module project, the mvn lifecycle will first be executed in the root of the project, then the container build will be executed for the module specified with the module-name input.
-# If your multi-module project has multiple bootable modules that you want in separate containers, you can reference this workflow multiple times with different module-name inputs.
-# For non-containerized applications, you can set enable-image-build to false to skip the image build and image scan steps. This will allow you to use this workflow for library projects as well.
-
+# Workflow Name: PR checks
+#
+# Purpose:
+#   This is the golden path for PRs towards main branch. This workflow handles
+#   both Maven library builds and containerized builds.
+#
+#.  Flow:
+#     1. Verifies PR title
+#     2. Builds and runs application from root pom with mvn lifecycle chosen in
+#        inputs (default: test).
+#     3. Scans with Trivy FS scan to fail fast on library vulnerabilities
+#     4. Builds image using paketo buildpacks (if 'enable-image-build' is true)
+#     5. Scans image with Trivy image scan for containerized/image-build
+#.       workflows (gated by 'enable-image-build' and 'application-type'; OS
+#        scanning is separately controlled by trivy-os-disable-scan)
+#     6. Auto-merges Dependabot PRs (optional)
+#
+#   If you are building a library project, you can set 'enable-image-build' to
+#   false to skip the image build and image scan steps. If you have a
+#   multi-module project, the mvn lifecycle will first be executed in the root
+#   of the project, then the container build will be executed for the module
+#   specified with the 'module-name' input. If your multi-module project has
+#   multiple bootable modules that you want in separate containers, you can
+#   reference this workflow multiple times with different module-name inputs.
+#   For non-containerized applications, you can set 'enable-image-build' to .
+#   'false' to skip the image build and image scan steps. This will allow you to
+#   use this workflow for library projects as well.
+#
+# Trigger:
+#   Triggered by workflow calls (workflow_call)
+#
+# Inputs:
+#   See input section
+#
+# Outputs:
+#   None
 
 name: PR Checks
 
@@ -22,19 +43,23 @@ on:
   workflow_call:
     inputs:
       enable-image-build:
+        description: Set to false to skip the image build and image scan steps
         type: boolean
         default: true
-        description: Set to false to skip the image build and image scan steps.
       application-type:
+        description: Type of application to determine container build and scan steps. Supported values are 'spring-boot' and 'quarkus'
         type: string
         required: true
       enable-auto-merge-dependabot:
+        description: Set to true to enable auto-merge for Dependabot PRs
         type: boolean
         default: false
       enable-pr-title-verify:
+        description: Set to true to enable PR title verification
         type: boolean
         default: true
       java-version:
+        description: Java version to use
         default: "21"
         required: false
         type: string
@@ -53,41 +78,51 @@ on:
         required: false
         type: string
       image-pack-tag:
-        description: "Docker image pack version tag. Earlier pinned to 0.0.440 due to lifecycle 0.21.2 regression (see: paketo-buildpacks/builder-noble-java-tiny#191). Now fixed: https://github.com/paketo-buildpacks/builder-noble-java-tiny/issues/191#issuecomment-3897508140"
+        description: "Docker image pack version tag"
         default: "latest"
         required: false
         type: string
       auto-merge-types:
+        description: "Comma-separated list of update types to auto-merge when 'enable-auto-merge-dependabot' is true. Supported values can be seen in 'update-types' under https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#ignore--"
         type: string
       pull-request-title:
+        description: Pull request title to validate
         type: string
         required: true
       pull-request-allowed-prefixes:
+        description: Comma-separated list of allowed prefixes for pull request title validation
         type: string
         required: true
       pull-request-min-length-title:
+        description: Minimum length for pull request title validation
         type: number
         required: false
         default: 10
       pull-request-max-length-title:
+        description: Maximum length for pull request title validation
         type: number
         required: false
         default: 100
       pull-request-case-sensitive-prefix:
+        description: Whether to perform case-sensitive prefix matching for pull request title validation
         type: boolean
         required: false
         default: true
       artifact-name:
+        description: Name of artifact to upload after build and test step. If empty, no artifact will be uploaded
         type: string
         required: false
       artifact-path:
+        description: Path to the artifact to upload
         type: string
         required: false
       native:
+        description: Whether to build a native image with Quarkus (only applicable if application-type is 'quarkus')
         required: false
         type: boolean
         default: false
       cache-path:
+        description: Path to the file used for caching Maven dependencies. Default is set to root pom.xml, but can be set to a specific module pom.xml in multi-module projects to only cache dependencies for that module
         default: "**/pom.xml"
         required: false
         type: string
@@ -97,6 +132,7 @@ on:
         required: false
         default: 'test'
       application-path:
+        description: 'Path to the application to scan with Trivy. Default is root of the repository, but can be set to a specific module in multi-module projects.'
         default: "./"
         required: false
         type: string
@@ -140,7 +176,6 @@ on:
         type: string
         required: false
         default: ''
-      
 
 jobs:
   verify-pull-request-title:

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -104,8 +104,8 @@ jobs:
           cache: maven
           cache-dependency-path: ${{ inputs.cache-path }}
           server-id: github
-          server-username: MAVEN_USER
-          server-password: MAVEN_PASSWORD
+          server-username: GH_PACKAGES_READ_USER
+          server-password: GH_PACKAGES_READ_PAT
 
       - name: Install pack
         run: |
@@ -125,8 +125,8 @@ jobs:
       - name: Build native image with Maven/Quarkus
         if: inputs.native == true
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
         run: |
           pack build ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
             --path . \
@@ -138,15 +138,15 @@ jobs:
             --env BP_MAVEN_POM_FILE="./pom.xml" \
             --env BP_NATIVE_IMAGE="true" \
             --env LANG="C.UTF-8" \
-            --env MAVEN_USER="${{ env.MAVEN_USER }}" \
-            --env MAVEN_PASSWORD="${{ env.MAVEN_PASSWORD }}" \
+            --env GH_PACKAGES_READ_USER="${{ env.GH_PACKAGES_READ_USER }}" \
+            --env GH_PACKAGES_READ_PAT="${{ env.GH_PACKAGES_READ_PAT }}" \
             --creation-time now
 
       - name: Build image with Maven/Quarkus
         if: inputs.native == false
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
         run: |
           pack build ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} \
             --path . \
@@ -156,8 +156,8 @@ jobs:
             --volume "${HOME}/.m2:/home/cnb/.m2:rw" \
             --env BP_JVM_VERSION="${{ inputs.java-version }}" \
             --env BP_MAVEN_POM_FILE="./pom.xml" \
-            --env MAVEN_USER="${{ env.MAVEN_USER }}" \
-            --env MAVEN_PASSWORD="${{ env.MAVEN_PASSWORD }}" \
+            --env GH_PACKAGES_READ_USER="${{ env.GH_PACKAGES_READ_USER }}" \
+            --env GH_PACKAGES_READ_PAT="${{ env.GH_PACKAGES_READ_PAT }}" \
             --creation-time now
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -108,21 +108,21 @@ jobs:
           cache: maven
           cache-dependency-path: ${{ inputs.cache-path }}
           server-id: github
-          server-username: MAVEN_USER
-          server-password: MAVEN_PASSWORD
+          server-username: GH_PACKAGES_READ_USER
+          server-password: GH_PACKAGES_READ_PAT
 
       - name: Build image with Maven (module-name, skips tests)
         if: inputs.module-name != ''
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
         run: mvn install -DskipTests -B spring-boot:build-image -pl ${{ inputs.module-name }} -am -Dspring-boot.build-image.imageName=${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} -Dspring-boot.build-image.builder=paketobuildpacks/${{ inputs.image-pack }}:${{ inputs.image-pack-tag }}
 
       - name: Build image with Maven (application-path, skips tests)
         if: inputs.module-name == ''
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
         run: mvn -DskipTests -B spring-boot:build-image --file ${{ inputs.application-path }}pom.xml -Dspring-boot.build-image.imageName=${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }} -Dspring-boot.build-image.builder=paketobuildpacks/${{ inputs.image-pack }}:${{ inputs.image-pack-tag }}
 
       - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
This PR mainly ensures that the PR checks workflow now can be used with

- Container image repos (`spring-boot` or `quarkus`)
- Library repos (`spring-boot` or `quarkus`)
- Multi-module repos that potentially has both libraries and image builds

This change should make it possible to deprecate [ci-maven-build-lib.yml](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-maven-build-lib.yml) by passing in `enable-image-build` set to `false` for library repositories.
 
---

Additional changes:

- Improve doc section and add missing input descriptions
- Migrat from `MAVEN_USER` and `MAVEN_PASSWORD` to `GH_PACKAGES_READ_USER` and `GH_PACKAGES_READ_PAT` as these are the new best practice secrets to use (both credential pairs allow the PR workflows to pull internal Maven package dependencies)

PS! This also removes the `enable-trivy-image-scan` input which is currently used [by 12 repositories](https://github.com/search?q=enterprise%3Adigdir+%22enable-trivy-image-scan%22++NOT+is%3Aarchived+NOT+repo%3Afelleslosninger%2Fgithub-actions+NOT+repo%3Afelleslosninger%2Fpaotvers-developer-docs+NOT+repo%3Afelleslosninger%2Fpaotvers.io+NOT+repo%3Afelleslosninger%2Fold.paotvers.io+NOT+repo%3Afelleslosninger%2Fchangelog+NOT+repo%3Afelleslosninger%2Fgithub-workflows+NOT+repo%3Afelleslosninger%2Fplatform&type=code). When this is merged, all 12 repositories need to remove this input and replace it with `enable-image-build` set to `false` if you do not want to run image build/trivy scan.

---

Testing:

- [eproc-elma](https://github.com/felleslosninger/eproc-elma/actions/runs/26215843916/job/77137854738) (testing the full pipeline)
- [plattform-test-app](https://github.com/felleslosninger/plattform-test-app/actions/runs/26228870118) (image build and scan)
- [plattform-test-app](https://github.com/felleslosninger/plattform-test-app/actions/runs/26228870118) (library build and scan - skipped image build/scan)
- [plattform-test-app-quarkus](https://github.com/felleslosninger/plattform-test-app-quarkus/actions/runs/26233355151) (image build and scan)
- [plattform-test-app](https://github.com/felleslosninger/plattform-test-app-quarkus/actions/runs/26233355299) (library build and scan - skipped image build/scan)
- [idporten-quarkus-log](https://github.com/felleslosninger/idporten-quarkus-log/actions/runs/26248596916) (`enable-image-build` satt til `false`)
- [idporten-quarkus-log](https://github.com/felleslosninger/idporten-quarkus-log/actions/runs/26249546722) (`maven-clean` satt til `true`)
- [idporten-quarkus-log](https://github.com/felleslosninger/idporten-quarkus-log/actions/runs/26249642555) (`maven-update-snapshots` satt til `true`)