### PR TITLE
PF-2400 Migrere fra custom GitHub app token action til offisiell create-github-app-token action

### DIFF
--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -158,17 +158,14 @@ jobs:
             echo "sha=${{ github.sha }}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Install Dependencies
-        run: npm install @octokit/app@v13.1.8
-
       - name: Generate Token
-        uses: felleslosninger/github-actions/github-app-token@d7888fecafbf48e5845c8a0c76389f71c517ee6d # pin@v0.8.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # pin@v3.2.0
         id: token
         with:
-          app-id: ${{ secrets.DIGDIR_PLATFORM_CI_APP_ID }}
+          client-id: ${{ secrets.DIGDIR_PLATFORM_CI_APP_ID }}
           private-key: ${{ secrets.DIGDIR_PLATFORM_CI_APP_PRIVATE_KEY }}
-          installation-id: ${{ secrets.DIGDIR_PLATFORM_CI_APP_INSTALLATION_ID }}
-          repository: ${{ inputs.kubernetes-repo }}
+          owner: felleslosninger
+          repositories: ${{ inputs.kubernetes-repo }}
 
       - name: Log Outputs
         id: log-outputs


### PR DESCRIPTION
Migration of [custom github-app-token](https://github.com/felleslosninger/github-actions/tree/main/github-app-token) to [official GitHub actions/create-github-app-token](https://github.com/actions/create-github-app-token)
---
Changes

ci-call-update-image.yml
Replaced custom token action with actions/create-github-app-token.
Removed installation-id input.
Removed Install Dependencies step (npm install @octokit/app) which was only needed by the custom action.
Scoped token access 

---
Part of https://digdir.atlassian.net/browse/PF-2400