### PR TITLE
PF-2418 Sanitize and clean up Maven workflows

### DIFF
--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           mvn -B clean install --update-snapshots
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner (fs)
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           scan-type: "fs"

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -173,7 +173,7 @@ jobs:
               ;;
           esac
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner (fs)
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           scan-type: "fs"

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -154,15 +154,15 @@ jobs:
           cache: maven
           cache-dependency-path: ${{ inputs.cache-path }}
           server-id: github
-          server-username: MAVEN_USER
-          server-password: MAVEN_PASSWORD
+          server-username: GH_PACKAGES_READ_USER
+          server-password: GH_PACKAGES_READ_PAT
 
       - name: Run mvn ${{ inputs.maven-lifecycle }}
         env:
-          MAVEN_USER: ${{ secrets.MAVEN_USER }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
+          LIFECYCLE: ${{ inputs.maven-lifecycle }}
         run: |
-          LIFECYCLE="${{ inputs.maven-lifecycle }}"
           case "$LIFECYCLE" in
             test|package|verify|install)
               mvn -B "$LIFECYCLE"

--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -95,7 +95,15 @@ on:
         default: ''
 
 jobs:
-  build:
+  inputs-to-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write inputs to summary
+        uses: felleslosninger/github-workflows/.github/actions/json-to-summary@main
+        with:
+          json-payload: ${{ toJson(inputs) }}
+
+  build-publish-package:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -128,9 +136,10 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
+          PACKAGE_VERSION: ${{ inputs.package-version }}
         run: |
-          if [ "${{ inputs.package-version }}" != "" ]; then
-            mvn versions:set -B -DnewVersion="${{ inputs.package-version }}"
+          if [ "$PACKAGE_VERSION" != "" ]; then
+            mvn versions:set -B -DnewVersion="$PACKAGE_VERSION"
             echo "- \`mvn versions\` was executed" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- \`mvn versions\` was not executed" >> "$GITHUB_STEP_SUMMARY"
@@ -140,12 +149,14 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
+          DEPLOYMENT_REPO: ${{ inputs.deployment-repository }}
         run: |
-          if [ "${{ inputs.deployment-repository }}" != "" ]; then
-            mvn -B deploy -DaltDeploymentRepository="github::default::https://maven.pkg.github.com/${{ inputs.deployment-repository }}"
-            echo "- \`mvn versions\` was executed" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$DEPLOYMENT_REPO" != "" ]; then
+            mvn -B deploy -DaltDeploymentRepository="github::https://maven.pkg.github.com/$DEPLOYMENT_REPO"
+            echo "- \`mvn deploy\` was executed with custom repository" >> "$GITHUB_STEP_SUMMARY"
           else
             mvn -B deploy
+            echo "- \`mvn deploy\` was executed without repository override" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Run Trivy SBOM generation

--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -122,7 +122,7 @@ jobs:
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner (fs)
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           scan-type: "fs"

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -160,7 +160,7 @@ jobs:
             mvn -B clean install --update-snapshots
           fi
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner (fs)
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           scan-type: "fs"

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -106,7 +106,15 @@ on:
         default: ''
 
 jobs:
-  build:
+  inputs-to-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write inputs to summary
+        uses: felleslosninger/github-workflows/.github/actions/json-to-summary@main
+        with:
+          json-payload: ${{ toJson(inputs) }}
+
+  build-publish-package:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -131,9 +139,10 @@ jobs:
         env:
           GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
           GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
+          PACKAGE_VERSION: ${{ inputs.package-version }}
         run: |
-          if [ "${{ inputs.package-version }}" != "" ]; then
-            mvn versions:set -B -DnewVersion="${{ inputs.package-version }}"
+          if [ -n "$PACKAGE_VERSION" ]; then
+            mvn versions:set -B -DnewVersion="$PACKAGE_VERSION"
             echo "- \`mvn versions\` was executed" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- \`mvn versions\` was not executed" >> "$GITHUB_STEP_SUMMARY"
@@ -143,9 +152,10 @@ jobs:
         env:
           GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
           GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
+          PROFILE: ${{ inputs.profile }}
         run: |
-          if [ -n "${{ inputs.profile }}" ]; then
-            mvn -B clean install --update-snapshots -P"${{ inputs.profile }}"
+          if [ -n "$PROFILE" ]; then
+            mvn -B clean install --update-snapshots -P"$PROFILE"
           else
             mvn -B clean install --update-snapshots
           fi
@@ -161,24 +171,32 @@ jobs:
           trivy-version: ${{ inputs.trivy-version }}
 
       - name: Overwrite m2 settings to publish libs
+        env:
+          PUBLISH_ACTOR: ${{ github.actor }}
+          PUBLISH_TOKEN: ${{ github.token }}
         run: |
-          echo "<settings><servers><server><id>github</id><username>${{ github.actor }}</username><password>${{ github.token }}</password></server></servers></settings>" > ~/.m2/settings.xml
+          echo "<settings><servers><server><id>github</id><username>${PUBLISH_ACTOR}</username><password>${PUBLISH_TOKEN}</password></server></servers></settings>" > ~/.m2/settings.xml
 
       - name: Maven deploy
+        env:
+          PROFILE: ${{ inputs.profile }}
+          DEPLOYMENT_REPO: ${{ inputs.deployment-repository }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
-          MAVEN_CMD="mvn -B deploy"
+          TARGET_DIR="${APP_PATH:-.}"
+          cd "$TARGET_DIR" || exit 1
 
-          if [ "${{ inputs.profile }}" != "" ]; then
-            MAVEN_CMD="$MAVEN_CMD -P${{ inputs.profile }}"
+          MAVEN_ARGS=("-B" "deploy")
+
+          if [ -n "$PROFILE" ]; then
+            MAVEN_ARGS+=("-P$PROFILE")
           fi
 
-          if [ "${{ inputs.deployment-repository }}" != "" ]; then
-            MAVEN_CMD="$MAVEN_CMD -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ inputs.deployment-repository }}"
+          if [ -n "$DEPLOYMENT_REPO" ]; then
+            MAVEN_ARGS+=("-DaltDeploymentRepository=github::https://maven.pkg.github.com/$DEPLOYMENT_REPO")
           fi
 
-          cd ${{ inputs.application-path }} # Move into module path if multi module project, default is "./" so no operation if not specified.
-
-          $MAVEN_CMD
+          mvn "${MAVEN_ARGS[@]}"
 
       # This is a temporary step specifically for handling multi-module
       # repositories with Trivy SBOM generation for Maven artifacts. We strip


### PR DESCRIPTION
This PR sanitizes inputs in all Maven workflows. [Official docs on this](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks).

This includes

- [Maven build lib](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-maven-build-lib.yml) (no changes needed)
- [Maven build](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-maven-build.yml)
- [Maven deploy lib](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-maven-deploy.yml)
- [Maven install/deploy lib](https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-maven-install-deploy-lib.yml)

---

Other changes

- Migrate to the best practice `GH_PACKAGES_READ_USER` and `GH_PACKAGES_READ_PAT` instead of `MAVEN_USER` and `MAVEN_PASSWORD`
- Add `inputs-to-summary` job for the Maven publish workflows
- Fix `altDeploymentRepository` syntax: `github::default::<url>` to github::<url>` (pipelines are complaining about this, and is a Maven 2.x syntax)
- Migrate to bash array for building the dynamic `MAVEN_CMD`, which is more robust

---

Testing:

Read https://github.com/felleslosninger/platform/blob/main/docs/pipeline/how-to/pipeline-testing.md#maven-builds-on-main-packages on how to test. 

- Maven build: https://github.com/felleslosninger/plattform-test-app/actions/runs/27141162346?pr=521
- Maven publish: https://github.com/felleslosninger/plattform-test-app/actions/runs/27140750273
- Maven publish/install: https://github.com/felleslosninger/plattform-test-app-quarkus/actions/runs/27141756190