### PR TITLE
PF-2464 New composite action for PR title validation

### DIFF
--- a/.github/actions/validate-pr-title/README.md
+++ b/.github/actions/validate-pr-title/README.md
@@ -1,0 +1,67 @@
+# GitHub Action: Validate PR Title
+
+Author: **Digdir Platform Team / Digdir Development Teams**
+
+## Description
+
+This composite action provides lightweight, bash-based validation for Pull
+Request titles to enforce naming conventions and standards across repositories.
+By enforcing some standards, it makes tracking work much easier (e.g. via Jira).
+
+It supports:
+
+- Automatic PR title detection directly from the GitHub event context
+- Required prefix validation against a standard list (e.g., `ID-`, `Bump`,
+  `MP-`)
+- Minimum and maximum title length enforcement
+- Optional case-sensitive or case-insensitive prefix matching
+- Seamless fallback to golden-path defaults, requiring zero configuration for
+  standard applications
+
+## Inputs
+
+| Input | Description | Required | Default |
+| :---- | :---------- | :------- | :------ |
+| `pull-request-title` | The title of the PR. Defaults to the actual PR title if omitted. | false | `""` |
+| `allowed-prefixes` | Override allowed prefixes. Leave empty to use standard defaults (`Bump, ID-, MIN-, PBLEID-, MP-, KRR-, PF-, AOS-, SP-, EUW-, MOVE-`). | false | `""` |
+| `min-length-title` | Minimum length of the title. Defaults to `10`. | false | `""` |
+| `max-length-title` | Maximum length of the title (`-1` to disable). Defaults to `100`. | false | `""` |
+| `case-sensitive-prefix` | Whether prefix validation is case-sensitive (`true` or `false`). Defaults to `false`. | false | `""` |
+
+## Outputs
+
+This action does not generate explicit workflow outputs. Instead, it natively
+fails the workflow step (`exit 1`) and prints a standard GitHub Actions
+`::error::` annotation if the PR title fails any validation checks.
+
+## Example usage
+
+This action is normally used via reusable workflows, and because of how it's
+built, should not require any overrides to use sane defaults. In a reusable
+workflow it is normally implemented as a separate job that runs in parallell
+with other jobs
+
+```yaml
+  validate-pr-title:
+    if: |
+      inputs.enable-pr-title-verify == true &&
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@main
+        with:
+          pull-request-title: ${{ inputs.pull-request-title }}
+          allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}
+          min-length-title: ${{ inputs.pull-request-min-length-title }}
+          max-length-title: ${{ inputs.pull-request-max-length-title }}
+          case-sensitive-prefix: ${{ inputs.pull-request-case-sensitive-prefix }}
+```
+
+## How it works
+
+The action relies on a fast, dependency-free bash script. It first checks if
+specific input variables were provided. If inputs are left empty, it gracefully
+falls back to defaults within the bash script to avoid duplicating inputs in
+reusable workflows that uses the action. This means that the only place to
+handle defaults are within the script itself.

--- a/.github/actions/validate-pr-title/action.yml
+++ b/.github/actions/validate-pr-title/action.yml
@@ -1,0 +1,90 @@
+name: Validate PR Title
+description: Validation for Pull Request titles
+author: Digdir Platform Team / Digdir Development Team
+
+inputs:
+  pull-request-title:
+    description: The title of the pull request
+    required: true
+  allowed-prefixes:
+    description: Comma-separated list of allowed prefixes
+    required: false
+    default: "Bump,ID-,MIN-,PBLEID-,MP-,KRR-,PF-,AOS-,SP-,EIN-,EUW-,MOVE-"
+  min-length-title:
+    description: Minimum length of the title
+    required: false
+    default: '10'
+  max-length-title:
+    description: Maximum length of the title (-1 to disable)
+    required: false
+    default: '100'
+  case-sensitive-prefix:
+    description: Whether prefix validation is case-sensitive ("true" or "false")
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Write inputs to summary
+      uses: felleslosninger/github-workflows/.github/actions/json-to-summary@main
+      with:
+        json-payload: ${{ toJson(inputs) }}
+
+    - name: Validate Pull Request Title
+      shell: bash
+      env:
+        PR_TITLE: ${{ inputs.pull-request-title }}
+        ALLOWED_PREFIXES: ${{ inputs.allowed-prefixes }}
+        MIN_LENGTH: ${{ inputs.min-length-title }}
+        MAX_LENGTH: ${{ inputs.max-length-title }}
+        CASE_SENSITIVE: ${{ inputs.case-sensitive-prefix }}
+        REGEX_MATCH: ${{ inputs.regex-match }}
+      run: |
+        # Length checks
+        TITLE_LEN=${#PR_TITLE}
+
+        if [[ "$TITLE_LEN" -lt "$MIN_LENGTH" ]]; then
+          echo "::error::Pull Request title '$PR_TITLE' is shorter than the minimum length ($MIN_LENGTH)."
+          exit 1
+        fi
+
+        if [[ "$MAX_LENGTH" -gt 0 ]] && [[ "$TITLE_LEN" -gt "$MAX_LENGTH" ]]; then
+          echo "::error::Pull Request title '$PR_TITLE' is longer than the maximum length ($MAX_LENGTH)."
+          exit 1
+        fi
+
+        # Prefix check
+        if [[ -n "$ALLOWED_PREFIXES" ]]; then
+          # Convert comma-separated string to an array
+          IFS=',' read -ra PREFIX_ARRAY <<< "$ALLOWED_PREFIXES"
+          MATCH_FOUND=false
+
+          for RAW_PREFIX in "${PREFIX_ARRAY[@]}"; do
+            # Trim leading/trailing whitespace using xargs
+            PREFIX=$(echo "$RAW_PREFIX" | xargs)
+
+            if [[ "$CASE_SENSITIVE" == "true" ]]; then
+              if [[ "$PR_TITLE" == "$PREFIX"* ]]; then
+                MATCH_FOUND=true
+                break
+              fi
+            else
+              # Case-insensitive match using bash parameter expansion
+              TITLE_LOWER="${PR_TITLE,,}"
+              PREFIX_LOWER="${PREFIX,,}"
+
+              if [[ "$TITLE_LOWER" == "$PREFIX_LOWER"* ]]; then
+                MATCH_FOUND=true
+                break
+              fi
+            fi
+          done
+
+          if [[ "$MATCH_FOUND" == "false" ]]; then
+            echo "::error::Pull Request title '$PR_TITLE' did not start with any of the allowed prefixes: $ALLOWED_PREFIXES"
+            exit 1
+          fi
+        fi
+
+        echo "::notice::Pull request title passed all validation checks!"

--- a/.github/actions/validate-pr-title/action.yml
+++ b/.github/actions/validate-pr-title/action.yml
@@ -9,7 +9,7 @@ inputs:
   allowed-prefixes:
     description: Comma-separated list of allowed prefixes
     required: false
-    default: "Bump,ID-,MIN-,PBLEID-,MP-,KRR-,PF-,AOS-,SP-,EIN-,EUW-,MOVE-"
+    default: "Bump,Revert,ID-,MIN-,PBLEID-,MP-,KRR-,PF-,AOS-,SP-,EIN-,EUW-,MOVE-"
   min-length-title:
     description: Minimum length of the title
     required: false

--- a/.github/actions/validate-pr-title/action.yml
+++ b/.github/actions/validate-pr-title/action.yml
@@ -4,24 +4,25 @@ author: Digdir Platform Team / Digdir Development Team
 
 inputs:
   pull-request-title:
-    description: The title of the pull request
-    required: true
+    description: "The title of the PR. Defaults to actual PR title if omitted."
+    required: false
+    default: ''
   allowed-prefixes:
-    description: Comma-separated list of allowed prefixes
+    description: "Override allowed prefixes. Leave empty for standard defaults."
     required: false
-    default: "Bump,Revert,ID-,MIN-,PBLEID-,MP-,KRR-,PF-,AOS-,SP-,EIN-,EUW-,MOVE-"
+    default: ''
   min-length-title:
-    description: Minimum length of the title
+    description: "Minimum length of the title. Defaults to 10."
     required: false
-    default: '10'
+    default: ''
   max-length-title:
-    description: Maximum length of the title (-1 to disable)
+    description: "Maximum length of the title (-1 to disable). Defaults to 100."
     required: false
-    default: '100'
+    default: ''
   case-sensitive-prefix:
-    description: Whether prefix validation is case-sensitive ("true" or "false")
+    description: "Whether prefix validation is case-sensitive. Defaults to false."
     required: false
-    default: 'false'
+    default: ''
 
 runs:
   using: composite
@@ -34,12 +35,23 @@ runs:
     - name: Validate Pull Request Title
       shell: bash
       env:
-        PR_TITLE: ${{ inputs.pull-request-title }}
-        ALLOWED_PREFIXES: ${{ inputs.allowed-prefixes }}
-        MIN_LENGTH: ${{ inputs.min-length-title }}
-        MAX_LENGTH: ${{ inputs.max-length-title }}
-        CASE_SENSITIVE: ${{ inputs.case-sensitive-prefix }}
+        INPUT_TITLE: ${{ inputs.pull-request-title }}
+        EVENT_TITLE: ${{ github.event.pull_request.title }}
+        INPUT_PREFIXES: ${{ inputs.allowed-prefixes }}
+        INPUT_MIN_LENGTH: ${{ inputs.min-length-title }}
+        INPUT_MAX_LENGTH: ${{ inputs.max-length-title }}
+        INPUT_CASE_SENSITIVE: ${{ inputs.case-sensitive-prefix }}
       run: |
+        # Evaluate inputs and fallbacks
+        PR_TITLE="${INPUT_TITLE:-$EVENT_TITLE}"
+        MIN_LENGTH="${INPUT_MIN_LENGTH:-10}"
+        MAX_LENGTH="${INPUT_MAX_LENGTH:-100}"
+        CASE_SENSITIVE="${INPUT_CASE_SENSITIVE:-false}"
+
+        # This is the only place to maintain default prefixes
+        STANDARD_PREFIXES="Bump, ID-, MIN-, PBLEID-, MP-, KRR-, PF-, AOS-, SP-, EUW-, MOVE-"
+        ACTIVE_PREFIXES="${INPUT_PREFIXES:-$STANDARD_PREFIXES}"
+
         # Length checks
         TITLE_LEN=${#PR_TITLE}
 
@@ -54,9 +66,9 @@ runs:
         fi
 
         # Prefix check
-        if [[ -n "$ALLOWED_PREFIXES" ]]; then
+        if [[ -n "$ACTIVE_PREFIXES" ]]; then
           # Convert comma-separated string to an array
-          IFS=',' read -ra PREFIX_ARRAY <<< "$ALLOWED_PREFIXES"
+          IFS=',' read -ra PREFIX_ARRAY <<< "$ACTIVE_PREFIXES"
           MATCH_FOUND=false
 
           for RAW_PREFIX in "${PREFIX_ARRAY[@]}"; do
@@ -81,7 +93,7 @@ runs:
           done
 
           if [[ "$MATCH_FOUND" == "false" ]]; then
-            echo "::error::Pull Request title '$PR_TITLE' did not start with any of the allowed prefixes: $ALLOWED_PREFIXES"
+            echo "::error::Pull Request title '$PR_TITLE' did not start with any of the allowed prefixes: $ACTIVE_PREFIXES."
             exit 1
           fi
         fi

--- a/.github/actions/validate-pr-title/action.yml
+++ b/.github/actions/validate-pr-title/action.yml
@@ -39,7 +39,6 @@ runs:
         MIN_LENGTH: ${{ inputs.min-length-title }}
         MAX_LENGTH: ${{ inputs.max-length-title }}
         CASE_SENSITIVE: ${{ inputs.case-sensitive-prefix }}
-        REGEX_MATCH: ${{ inputs.regex-match }}
       run: |
         # Length checks
         TITLE_LEN=${#PR_TITLE}

--- a/.github/actions/validate-pr-title/action.yml
+++ b/.github/actions/validate-pr-title/action.yml
@@ -49,7 +49,7 @@ runs:
         CASE_SENSITIVE="${INPUT_CASE_SENSITIVE:-false}"
 
         # This is the only place to maintain default prefixes
-        STANDARD_PREFIXES="Bump, ID-, MIN-, PBLEID-, MP-, KRR-, PF-, AOS-, SP-, EUW-, MOVE-"
+        STANDARD_PREFIXES="Bump, ID-, MIN-, MP-, KRR-, PF-, AOS-, SP-, EUW-, MOVE-"
         ACTIVE_PREFIXES="${INPUT_PREFIXES:-$STANDARD_PREFIXES}"
 
         # Length checks

--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@PF-2464-verify-pr-title-composite-action
+        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@main
         with:
           pull-request-title: ${{ inputs.pull-request-title }}
           allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}

--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -64,6 +64,35 @@ on:
         default: "./"
         required: false
         type: string
+      enable-pr-title-verify:
+        description: Set to true to enable PR title verification
+        type: boolean
+        default: true
+      pull-request-title:
+        description: Optional override for PR title (defaults to actual PR title)
+        type: string
+        required: false
+        default: ''
+      pull-request-allowed-prefixes:
+        description: Override allowed prefixes (defaults to standard prefixes)
+        type: string
+        required: false
+        default: ''
+      pull-request-min-length-title:
+        description:  Override minimum length (defaults to 10)
+        type: string
+        required: false
+        default: ''
+      pull-request-max-length-title:
+        description: Override maximum length (defaults to 100, -1 to disable)
+        type: string
+        required: false
+        default: ''
+      pull-request-case-sensitive-prefix:
+        description: Override case sensitivity ('true' or 'false'). Leave empty to use the standard default (false)
+        type: string
+        required: false
+        default: ''
       trivy-library-disable-scan:
         description: Disable Trivy library scan
         type: boolean
@@ -86,56 +115,20 @@ on:
         default: ''
 
 jobs:
-  verify-pull-request-title:
-    if: ${{ github.event_name == 'pull_request'}}
+  validate-pr-title:
+    if: |
+      inputs.enable-pr-title-verify == true &&
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # pin@v9.0.0
+      - name: Validate PR title
+        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@PF-2464-verify-pr-title-composite-action
         with:
-          script: |
-            const REGEX = new RegExp("^[^…]+$");  // Title must match this regex
-            const MIN_LENGTH = 10;                 // Min length of the title
-            const MAX_LENGTH = 100;                // Max length of the title (-1 is no max)
-            const ALLOWED_PREFIXES = ['Bump','ID-','MIN-','PBLEID-','MP-','KRR-','PF-','AOS-','SP-','EUW-','MOVE-'];         // Title must start with one of these prefixes
-            const PREFIX_CASE_SENSITIVE = false;  // Whether the prefix is case sensitive
-
-            const validateTitlePrefix = (title, prefix) =>
-              PREFIX_CASE_SENSITIVE
-                ? title.startsWith(prefix)
-                : title.toLowerCase().startsWith(prefix.toLowerCase());
-
-            const { title } = context.payload.pull_request;
-            if (!REGEX.test(title)) {
-              core.setFailed(
-                `Pull Request title "${title}" failed to match regex - ${REGEX}`
-              );
-              return;
-            }
-
-            if (title.length < MIN_LENGTH) {
-              core.setFailed(
-                `Pull Request title "${title}" is smaller than the minimum length - ${MIN_LENGTH}`
-              );
-              return;
-            }
-
-            if (MAX_LENGTH > 0 && title.length > MAX_LENGTH) {
-              core.setFailed(
-                `Pull Request title "${title}" is greater than the maximum length - ${MAX_LENGTH}`
-              );
-              return;
-            }
-
-            core.info(`Allowed Prefixes: ${ALLOWED_PREFIXES}`);
-            if (
-              ALLOWED_PREFIXES.length &&
-              !ALLOWED_PREFIXES.some((prefix) => validateTitlePrefix(title, prefix))
-            ) {
-              core.setFailed(
-                `Pull Request title "${title}" did not start with any of the required prefixes - ${ALLOWED_PREFIXES}`
-              );
-              return;
-            }
+          pull-request-title: ${{ inputs.pull-request-title }}
+          allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}
+          min-length-title: ${{ inputs.pull-request-min-length-title }}
+          max-length-title: ${{ inputs.pull-request-max-length-title }}
+          case-sensitive-prefix: ${{ inputs.pull-request-case-sensitive-prefix }}
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@PF-2464-verify-pr-title-composite-action
+        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@main
         with:
           pull-request-title: ${{ inputs.pull-request-title }}
           allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -65,6 +65,35 @@ on:
         type: string
         required: false
         default: 'test'
+      enable-pr-title-verify:
+        description: Set to true to enable PR title verification
+        type: boolean
+        default: true
+      pull-request-title:
+        description: Optional override for PR title (defaults to actual PR title)
+        type: string
+        required: false
+        default: ''
+      pull-request-allowed-prefixes:
+        description: Override allowed prefixes (defaults to standard prefixes)
+        type: string
+        required: false
+        default: ''
+      pull-request-min-length-title:
+        description:  Override minimum length (defaults to 10)
+        type: string
+        required: false
+        default: ''
+      pull-request-max-length-title:
+        description: Override maximum length (defaults to 100, -1 to disable)
+        type: string
+        required: false
+        default: ''
+      pull-request-case-sensitive-prefix:
+        description: Override case sensitivity ('true' or 'false'). Leave empty to use the standard default (false)
+        type: string
+        required: false
+        default: ''
       trivy-library-disable-scan:
         description: Disable Trivy library scan
         type: boolean
@@ -87,56 +116,20 @@ on:
         default: ''
 
 jobs:
-  verify-pull-request-title:
-    if: ${{ github.event_name == 'pull_request'}}
+  validate-pr-title:
+    if: |
+      inputs.enable-pr-title-verify == true &&
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # pin@v9.0.0
+      - name: Validate PR title
+        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@PF-2464-verify-pr-title-composite-action
         with:
-          script: |
-            const REGEX = new RegExp("^[^…]+$");  // Title must match this regex
-            const MIN_LENGTH = 10;                 // Min length of the title
-            const MAX_LENGTH = 100;                // Max length of the title (-1 is no max)
-            const ALLOWED_PREFIXES = ['Bump','ID-','MIN-','PBLEID-','MP-','KRR-','PF-','AOS-','SP-','EIN-','EUW-','MOVE-'];          // Title must start with one of these prefixes
-            const PREFIX_CASE_SENSITIVE = false;  // Whether the prefix is case sensitive
-
-            const validateTitlePrefix = (title, prefix) =>
-              PREFIX_CASE_SENSITIVE
-                ? title.startsWith(prefix)
-                : title.toLowerCase().startsWith(prefix.toLowerCase());
-
-            const { title } = context.payload.pull_request;
-            if (!REGEX.test(title)) {
-              core.setFailed(
-                `Pull Request title "${title}" failed to match regex - ${REGEX}`
-              );
-              return;
-            }
-
-            if (title.length < MIN_LENGTH) {
-              core.setFailed(
-                `Pull Request title "${title}" is smaller than the minimum length - ${MIN_LENGTH}`
-              );
-              return;
-            }
-
-            if (MAX_LENGTH > 0 && title.length > MAX_LENGTH) {
-              core.setFailed(
-                `Pull Request title "${title}" is greater than the maximum length - ${MAX_LENGTH}`
-              );
-              return;
-            }
-
-            core.info(`Allowed Prefixes: ${ALLOWED_PREFIXES}`);
-            if (
-              ALLOWED_PREFIXES.length &&
-              !ALLOWED_PREFIXES.some((prefix) => validateTitlePrefix(title, prefix))
-            ) {
-              core.setFailed(
-                `Pull Request title "${title}" did not start with any of the required prefixes - ${ALLOWED_PREFIXES}`
-              );
-              return;
-            }
+          pull-request-title: ${{ inputs.pull-request-title }}
+          allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}
+          min-length-title: ${{ inputs.pull-request-min-length-title }}
+          max-length-title: ${{ inputs.pull-request-max-length-title }}
+          case-sensitive-prefix: ${{ inputs.pull-request-case-sensitive-prefix }}
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -97,6 +97,7 @@ on:
         description: Comma-separated list of allowed prefixes for pull request title validation
         type: string
         required: false
+        default: "Bump,Revert,ID-,MIN-,PBLEID-,MP-,KRR-,PF-,AOS-,SP-,EIN-,EUW-,MOVE-"
       pull-request-min-length-title:
         description: Minimum length for pull request title validation
         type: number

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@PF-2464-verify-pr-title-composite-action
+        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@main
         with:
           pull-request-title: ${{ inputs.pull-request-title }}
           allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@main
+        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@PF-2464-verify-pr-title-composite-action
         with:
           pull-request-title: ${{ inputs.pull-request-title }}
           min-length-title: ${{ inputs.pull-request-min-length-title }}

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -190,33 +190,20 @@ on:
         default: ''
 
 jobs:
-  verify-pull-request-title:
+  validate-pr-title:
     if: |
       inputs.enable-pr-title-verify == true &&
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR title
-        id: check-pr-title
-        uses: felleslosninger/github-actions/validate-pull-request-title@d7888fecafbf48e5845c8a0c76389f71c517ee6d # pin@v0.8.0
+      - name: Validate PR title
+        uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@main
         with:
           pull-request-title: ${{ inputs.pull-request-title }}
-          allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}
           min-length-title: ${{ inputs.pull-request-min-length-title }}
           max-length-title: ${{ inputs.pull-request-max-length-title }}
           case-sensitive-prefix: ${{ inputs.pull-request-case-sensitive-prefix }}
-
-      - name: Write inputs to summary
-        uses: felleslosninger/github-workflows/.github/actions/json-to-summary@main
-        with:
-          json-payload: ${{ toJson(inputs) }}
-
-      - name: Fail if PR title is not valid
-        if: steps.check-pr-title.outputs.is-valid == 'false'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # pin@v9.0.0
-        with:
-          script: |
-            core.setFailed('${{ steps.check-pr-title.outputs.error-message }}')
+          allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}
 
   build-and-test-java:
     if: |

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -207,169 +207,169 @@ jobs:
           max-length-title: ${{ inputs.pull-request-max-length-title }}
           case-sensitive-prefix: ${{ inputs.pull-request-case-sensitive-prefix }}
 
-  build-and-test-java:
-    if: |
-      inputs.application-type == 'spring-boot' ||
-      inputs.application-type == 'quarkus'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+  # build-and-test-java:
+  #   if: |
+  #     inputs.application-type == 'spring-boot' ||
+  #     inputs.application-type == 'quarkus'
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
-      - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
-        with:
-          distribution: "${{ inputs.java-distribution }}"
-          java-version: ${{ inputs.java-version }}
-          cache: maven
-          cache-dependency-path: ${{ inputs.cache-path }}
-          server-id: github
-          server-username: GH_PACKAGES_READ_USER
-          server-password: GH_PACKAGES_READ_PAT
+  #     - name: Set up JDK ${{ inputs.java-version }}
+  #       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+  #       with:
+  #         distribution: "${{ inputs.java-distribution }}"
+  #         java-version: ${{ inputs.java-version }}
+  #         cache: maven
+  #         cache-dependency-path: ${{ inputs.cache-path }}
+  #         server-id: github
+  #         server-username: GH_PACKAGES_READ_USER
+  #         server-password: GH_PACKAGES_READ_PAT
 
-      - name: Run mvn ${{ inputs.maven-lifecycle }}
-        env:
-          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
-          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
-          LIFECYCLE: ${{ inputs.maven-lifecycle }}
-          MAVEN_CLEAN: ${{ inputs.maven-clean }}
-          UPDATE_SNAPSHOTS: ${{ inputs.maven-update-snapshots }}
-        run: |
-          case "$LIFECYCLE" in
-            test|package|verify|install)
-              ;;
-            *)
-              echo "Invalid Maven lifecycle: $LIFECYCLE"
-              exit 1
-              ;;
-          esac
+  #     - name: Run mvn ${{ inputs.maven-lifecycle }}
+  #       env:
+  #         GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+  #         GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
+  #         LIFECYCLE: ${{ inputs.maven-lifecycle }}
+  #         MAVEN_CLEAN: ${{ inputs.maven-clean }}
+  #         UPDATE_SNAPSHOTS: ${{ inputs.maven-update-snapshots }}
+  #       run: |
+  #         case "$LIFECYCLE" in
+  #           test|package|verify|install)
+  #             ;;
+  #           *)
+  #             echo "Invalid Maven lifecycle: $LIFECYCLE"
+  #             exit 1
+  #             ;;
+  #         esac
 
-          # Build the Maven command dynamically
-          ARGS=("-B")
+  #         # Build the Maven command dynamically
+  #         ARGS=("-B")
 
-          if [ "$MAVEN_CLEAN" == "true" ]; then
-            ARGS+=("clean")
-          fi
+  #         if [ "$MAVEN_CLEAN" == "true" ]; then
+  #           ARGS+=("clean")
+  #         fi
 
-          ARGS+=("$LIFECYCLE")
+  #         ARGS+=("$LIFECYCLE")
 
-          if [ "$UPDATE_SNAPSHOTS" == "true" ]; then
-            ARGS+=("--update-snapshots")
-          fi
+  #         if [ "$UPDATE_SNAPSHOTS" == "true" ]; then
+  #           ARGS+=("--update-snapshots")
+  #         fi
 
-          # Execute the Maven command
-          mvn "${ARGS[@]}"
+  #         # Execute the Maven command
+  #         mvn "${ARGS[@]}"
 
-      - name: Run Trivy vulnerability scanner (fs)
-        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
-        if: inputs.trivy-library-disable-scan == false
-        with:
-          scan-type: "fs"
-          application-path: ${{ inputs.application-path }}
-          library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
-          library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
-          library-severity: ${{ inputs.trivy-library-severity }}
-          trivy-version: ${{ inputs.trivy-version }}
+  #     - name: Run Trivy vulnerability scanner (fs)
+  #       uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
+  #       if: inputs.trivy-library-disable-scan == false
+  #       with:
+  #         scan-type: "fs"
+  #         application-path: ${{ inputs.application-path }}
+  #         library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+  #         library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+  #         library-severity: ${{ inputs.trivy-library-severity }}
+  #         trivy-version: ${{ inputs.trivy-version }}
 
-      - name: Upload artifact
-        if: |
-          !cancelled() &&
-          inputs.artifact-path != ''
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: ${{ inputs.artifact-path }}
+  #     - name: Upload artifact
+  #       if: |
+  #         !cancelled() &&
+  #         inputs.artifact-path != ''
+  #       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
+  #       with:
+  #         name: ${{ inputs.artifact-name }}
+  #         path: ${{ inputs.artifact-path }}
 
-  call-spring-boot-container-scan:
-    name: Call Spring Boot container scan
-    needs: build-and-test-java
-    if: |
-      inputs.enable-image-build == true &&
-      inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
-    permissions:
-      contents: read
-    with:
-      image-name: ${{ inputs.image-name }}
-      image-pack: ${{ inputs.image-pack }}
-      image-pack-tag: ${{ inputs.image-pack-tag }}
-      java-version: ${{ inputs.java-version }}
-      application-path: ${{ inputs.application-path }}
-      module-name: ${{ inputs.module-name }}
-      trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
-      trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
-      trivy-library-severity: ${{ inputs.trivy-library-severity }}
-      trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
-      trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
-      trivy-os-severity: ${{ inputs.trivy-os-severity }}
-      trivy-version: ${{ inputs.trivy-version }}
-    secrets: inherit
+  # call-spring-boot-container-scan:
+  #   name: Call Spring Boot container scan
+  #   needs: build-and-test-java
+  #   if: |
+  #     inputs.enable-image-build == true &&
+  #     inputs.application-type == 'spring-boot'
+  #   uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
+  #   permissions:
+  #     contents: read
+  #   with:
+  #     image-name: ${{ inputs.image-name }}
+  #     image-pack: ${{ inputs.image-pack }}
+  #     image-pack-tag: ${{ inputs.image-pack-tag }}
+  #     java-version: ${{ inputs.java-version }}
+  #     application-path: ${{ inputs.application-path }}
+  #     module-name: ${{ inputs.module-name }}
+  #     trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+  #     trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+  #     trivy-library-severity: ${{ inputs.trivy-library-severity }}
+  #     trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
+  #     trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
+  #     trivy-os-severity: ${{ inputs.trivy-os-severity }}
+  #     trivy-version: ${{ inputs.trivy-version }}
+  #   secrets: inherit
 
-  call-quarkus-container-scan:
-    name: Call Quarkus container scan
-    needs: build-and-test-java
-    if: |
-      inputs.enable-image-build == true &&
-      inputs.application-type == 'quarkus'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
-    permissions:
-      contents: read
-    with:
-      image-name: ${{ inputs.image-name }}
-      image-pack: ${{ inputs.image-pack }}
-      image-pack-tag: ${{ inputs.image-pack-tag }}
-      java-version: ${{ inputs.java-version }}
-      native: ${{ inputs.native }}
-      application-path: ${{ inputs.application-path }}
-      trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
-      trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
-      trivy-library-severity: ${{ inputs.trivy-library-severity }}
-      trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
-      trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
-      trivy-os-severity: ${{ inputs.trivy-os-severity }}
-      trivy-version: ${{ inputs.trivy-version }}
-    secrets: inherit
+  # call-quarkus-container-scan:
+  #   name: Call Quarkus container scan
+  #   needs: build-and-test-java
+  #   if: |
+  #     inputs.enable-image-build == true &&
+  #     inputs.application-type == 'quarkus'
+  #   uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
+  #   permissions:
+  #     contents: read
+  #   with:
+  #     image-name: ${{ inputs.image-name }}
+  #     image-pack: ${{ inputs.image-pack }}
+  #     image-pack-tag: ${{ inputs.image-pack-tag }}
+  #     java-version: ${{ inputs.java-version }}
+  #     native: ${{ inputs.native }}
+  #     application-path: ${{ inputs.application-path }}
+  #     trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+  #     trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+  #     trivy-library-severity: ${{ inputs.trivy-library-severity }}
+  #     trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
+  #     trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
+  #     trivy-os-severity: ${{ inputs.trivy-os-severity }}
+  #     trivy-version: ${{ inputs.trivy-version }}
+  #   secrets: inherit
 
-  call-auto-merge:
-    name: Call auto-merge
-    if: |
-      always() &&
-      inputs.enable-auto-merge-dependabot == true &&
-      (needs.build-and-test-java.result == 'success' || needs.build-and-test-java.result == 'skipped') &&
-      (needs.call-spring-boot-container-scan.result == 'success' || needs.call-spring-boot-container-scan.result == 'skipped') &&
-      (needs.call-quarkus-container-scan.result == 'success' || needs.call-quarkus-container-scan.result == 'skipped')
-    needs:
-      [
-        build-and-test-java,
-        call-spring-boot-container-scan,
-        call-quarkus-container-scan,
-      ]
-    uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@main
-    permissions:
-      contents: write
-      pull-requests: write
-    with:
-      update-types: ${{ inputs.auto-merge-types }}
-    secrets: inherit
+  # call-auto-merge:
+  #   name: Call auto-merge
+  #   if: |
+  #     always() &&
+  #     inputs.enable-auto-merge-dependabot == true &&
+  #     (needs.build-and-test-java.result == 'success' || needs.build-and-test-java.result == 'skipped') &&
+  #     (needs.call-spring-boot-container-scan.result == 'success' || needs.call-spring-boot-container-scan.result == 'skipped') &&
+  #     (needs.call-quarkus-container-scan.result == 'success' || needs.call-quarkus-container-scan.result == 'skipped')
+  #   needs:
+  #     [
+  #       build-and-test-java,
+  #       call-spring-boot-container-scan,
+  #       call-quarkus-container-scan,
+  #     ]
+  #   uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@main
+  #   permissions:
+  #     contents: write
+  #     pull-requests: write
+  #   with:
+  #     update-types: ${{ inputs.auto-merge-types }}
+  #   secrets: inherit
 
-  # PS! At some point, after GitHub made changes to how Dependabot permissions
-  # worked, this step was skipped automatically. The Platform team thinks this
-  # is actually good, as we do not really want to support this behaviour because
-  # of supply-chain security concerns. It means that the Platform team do not
-  # want to encourage automatic image deployment of automatically merged
-  # Dependabot PRs without human oversight. This step will probably be removed
-  # in the future, but for now it is left in the workflow until it has been
-  # discussed further.
-  call-build-image:
-    name: Call build image
-    if: needs.call-auto-merge.outputs.merged == 'true'
-    runs-on: ubuntu-latest
-    needs: call-auto-merge
-    steps:
-      - name: call-build-publish-image
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
-        with:
-          event-type: build-publish-image
+  # # PS! At some point, after GitHub made changes to how Dependabot permissions
+  # # worked, this step was skipped automatically. The Platform team thinks this
+  # # is actually good, as we do not really want to support this behaviour because
+  # # of supply-chain security concerns. It means that the Platform team do not
+  # # want to encourage automatic image deployment of automatically merged
+  # # Dependabot PRs without human oversight. This step will probably be removed
+  # # in the future, but for now it is left in the workflow until it has been
+  # # discussed further.
+  # call-build-image:
+  #   name: Call build image
+  #   if: needs.call-auto-merge.outputs.merged == 'true'
+  #   runs-on: ubuntu-latest
+  #   needs: call-auto-merge
+  #   steps:
+  #     - name: call-build-publish-image
+  #       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
+  #       with:
+  #         event-type: build-publish-image

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -96,7 +96,7 @@ on:
       pull-request-allowed-prefixes:
         description: Comma-separated list of allowed prefixes for pull request title validation
         type: string
-        required: true
+        required: false
       pull-request-min-length-title:
         description: Minimum length for pull request title validation
         type: number

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -90,29 +90,30 @@ on:
         description: "Comma-separated list of update types to auto-merge when 'enable-auto-merge-dependabot' is true. Supported values can be seen in 'update-types' under https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#ignore--"
         type: string
       pull-request-title:
-        description: Pull request title to validate
+        description: Optional override for PR title (defaults to actual PR title)
         type: string
-        required: true
+        required: false
+        default: ''
       pull-request-allowed-prefixes:
-        description: Comma-separated list of allowed prefixes for pull request title validation
+        description: Override allowed prefixes (defaults to standard prefixes)
         type: string
         required: false
-        default: "Bump,Revert,ID-,MIN-,PBLEID-,MP-,KRR-,PF-,AOS-,SP-,EIN-,EUW-,MOVE-"
+        default: ''
       pull-request-min-length-title:
-        description: Minimum length for pull request title validation
-        type: number
+        description:  Override minimum length (defaults to 10)
+        type: string
         required: false
-        default: 10
+        default: ''
       pull-request-max-length-title:
-        description: Maximum length for pull request title validation
-        type: number
+        description: Override maximum length (defaults to 100, -1 to disable)
+        type: string
         required: false
-        default: 100
+        default: ''
       pull-request-case-sensitive-prefix:
-        description: Whether to perform case-sensitive prefix matching for pull request title validation
-        type: boolean
+        description: Override case sensitivity ('true' or 'false'). Leave empty to use the standard default (false)
+        type: string
         required: false
-        default: true
+        default: ''
       artifact-name:
         description: Name of artifact to upload after build and test step. If empty, no artifact will be uploaded
         type: string
@@ -201,10 +202,10 @@ jobs:
         uses: felleslosninger/github-workflows/.github/actions/validate-pr-title@PF-2464-verify-pr-title-composite-action
         with:
           pull-request-title: ${{ inputs.pull-request-title }}
+          allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}
           min-length-title: ${{ inputs.pull-request-min-length-title }}
           max-length-title: ${{ inputs.pull-request-max-length-title }}
           case-sensitive-prefix: ${{ inputs.pull-request-case-sensitive-prefix }}
-          allowed-prefixes: ${{ inputs.pull-request-allowed-prefixes }}
 
   build-and-test-java:
     if: |

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -207,169 +207,169 @@ jobs:
           max-length-title: ${{ inputs.pull-request-max-length-title }}
           case-sensitive-prefix: ${{ inputs.pull-request-case-sensitive-prefix }}
 
-  # build-and-test-java:
-  #   if: |
-  #     inputs.application-type == 'spring-boot' ||
-  #     inputs.application-type == 'quarkus'
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
+  build-and-test-java:
+    if: |
+      inputs.application-type == 'spring-boot' ||
+      inputs.application-type == 'quarkus'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
-  #     - name: Set up JDK ${{ inputs.java-version }}
-  #       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
-  #       with:
-  #         distribution: "${{ inputs.java-distribution }}"
-  #         java-version: ${{ inputs.java-version }}
-  #         cache: maven
-  #         cache-dependency-path: ${{ inputs.cache-path }}
-  #         server-id: github
-  #         server-username: GH_PACKAGES_READ_USER
-  #         server-password: GH_PACKAGES_READ_PAT
+      - name: Set up JDK ${{ inputs.java-version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        with:
+          distribution: "${{ inputs.java-distribution }}"
+          java-version: ${{ inputs.java-version }}
+          cache: maven
+          cache-dependency-path: ${{ inputs.cache-path }}
+          server-id: github
+          server-username: GH_PACKAGES_READ_USER
+          server-password: GH_PACKAGES_READ_PAT
 
-  #     - name: Run mvn ${{ inputs.maven-lifecycle }}
-  #       env:
-  #         GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
-  #         GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
-  #         LIFECYCLE: ${{ inputs.maven-lifecycle }}
-  #         MAVEN_CLEAN: ${{ inputs.maven-clean }}
-  #         UPDATE_SNAPSHOTS: ${{ inputs.maven-update-snapshots }}
-  #       run: |
-  #         case "$LIFECYCLE" in
-  #           test|package|verify|install)
-  #             ;;
-  #           *)
-  #             echo "Invalid Maven lifecycle: $LIFECYCLE"
-  #             exit 1
-  #             ;;
-  #         esac
+      - name: Run mvn ${{ inputs.maven-lifecycle }}
+        env:
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
+          LIFECYCLE: ${{ inputs.maven-lifecycle }}
+          MAVEN_CLEAN: ${{ inputs.maven-clean }}
+          UPDATE_SNAPSHOTS: ${{ inputs.maven-update-snapshots }}
+        run: |
+          case "$LIFECYCLE" in
+            test|package|verify|install)
+              ;;
+            *)
+              echo "Invalid Maven lifecycle: $LIFECYCLE"
+              exit 1
+              ;;
+          esac
 
-  #         # Build the Maven command dynamically
-  #         ARGS=("-B")
+          # Build the Maven command dynamically
+          ARGS=("-B")
 
-  #         if [ "$MAVEN_CLEAN" == "true" ]; then
-  #           ARGS+=("clean")
-  #         fi
+          if [ "$MAVEN_CLEAN" == "true" ]; then
+            ARGS+=("clean")
+          fi
 
-  #         ARGS+=("$LIFECYCLE")
+          ARGS+=("$LIFECYCLE")
 
-  #         if [ "$UPDATE_SNAPSHOTS" == "true" ]; then
-  #           ARGS+=("--update-snapshots")
-  #         fi
+          if [ "$UPDATE_SNAPSHOTS" == "true" ]; then
+            ARGS+=("--update-snapshots")
+          fi
 
-  #         # Execute the Maven command
-  #         mvn "${ARGS[@]}"
+          # Execute the Maven command
+          mvn "${ARGS[@]}"
 
-  #     - name: Run Trivy vulnerability scanner (fs)
-  #       uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
-  #       if: inputs.trivy-library-disable-scan == false
-  #       with:
-  #         scan-type: "fs"
-  #         application-path: ${{ inputs.application-path }}
-  #         library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
-  #         library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
-  #         library-severity: ${{ inputs.trivy-library-severity }}
-  #         trivy-version: ${{ inputs.trivy-version }}
+      - name: Run Trivy vulnerability scanner (fs)
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
+        if: inputs.trivy-library-disable-scan == false
+        with:
+          scan-type: "fs"
+          application-path: ${{ inputs.application-path }}
+          library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+          library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+          library-severity: ${{ inputs.trivy-library-severity }}
+          trivy-version: ${{ inputs.trivy-version }}
 
-  #     - name: Upload artifact
-  #       if: |
-  #         !cancelled() &&
-  #         inputs.artifact-path != ''
-  #       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
-  #       with:
-  #         name: ${{ inputs.artifact-name }}
-  #         path: ${{ inputs.artifact-path }}
+      - name: Upload artifact
+        if: |
+          !cancelled() &&
+          inputs.artifact-path != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
 
-  # call-spring-boot-container-scan:
-  #   name: Call Spring Boot container scan
-  #   needs: build-and-test-java
-  #   if: |
-  #     inputs.enable-image-build == true &&
-  #     inputs.application-type == 'spring-boot'
-  #   uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
-  #   permissions:
-  #     contents: read
-  #   with:
-  #     image-name: ${{ inputs.image-name }}
-  #     image-pack: ${{ inputs.image-pack }}
-  #     image-pack-tag: ${{ inputs.image-pack-tag }}
-  #     java-version: ${{ inputs.java-version }}
-  #     application-path: ${{ inputs.application-path }}
-  #     module-name: ${{ inputs.module-name }}
-  #     trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
-  #     trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
-  #     trivy-library-severity: ${{ inputs.trivy-library-severity }}
-  #     trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
-  #     trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
-  #     trivy-os-severity: ${{ inputs.trivy-os-severity }}
-  #     trivy-version: ${{ inputs.trivy-version }}
-  #   secrets: inherit
+  call-spring-boot-container-scan:
+    name: Call Spring Boot container scan
+    needs: build-and-test-java
+    if: |
+      inputs.enable-image-build == true &&
+      inputs.application-type == 'spring-boot'
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
+    permissions:
+      contents: read
+    with:
+      image-name: ${{ inputs.image-name }}
+      image-pack: ${{ inputs.image-pack }}
+      image-pack-tag: ${{ inputs.image-pack-tag }}
+      java-version: ${{ inputs.java-version }}
+      application-path: ${{ inputs.application-path }}
+      module-name: ${{ inputs.module-name }}
+      trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+      trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+      trivy-library-severity: ${{ inputs.trivy-library-severity }}
+      trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
+      trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
+      trivy-os-severity: ${{ inputs.trivy-os-severity }}
+      trivy-version: ${{ inputs.trivy-version }}
+    secrets: inherit
 
-  # call-quarkus-container-scan:
-  #   name: Call Quarkus container scan
-  #   needs: build-and-test-java
-  #   if: |
-  #     inputs.enable-image-build == true &&
-  #     inputs.application-type == 'quarkus'
-  #   uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
-  #   permissions:
-  #     contents: read
-  #   with:
-  #     image-name: ${{ inputs.image-name }}
-  #     image-pack: ${{ inputs.image-pack }}
-  #     image-pack-tag: ${{ inputs.image-pack-tag }}
-  #     java-version: ${{ inputs.java-version }}
-  #     native: ${{ inputs.native }}
-  #     application-path: ${{ inputs.application-path }}
-  #     trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
-  #     trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
-  #     trivy-library-severity: ${{ inputs.trivy-library-severity }}
-  #     trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
-  #     trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
-  #     trivy-os-severity: ${{ inputs.trivy-os-severity }}
-  #     trivy-version: ${{ inputs.trivy-version }}
-  #   secrets: inherit
+  call-quarkus-container-scan:
+    name: Call Quarkus container scan
+    needs: build-and-test-java
+    if: |
+      inputs.enable-image-build == true &&
+      inputs.application-type == 'quarkus'
+    uses: felleslosninger/github-workflows/.github/workflows/ci-quarkus-container-scan.yml@main
+    permissions:
+      contents: read
+    with:
+      image-name: ${{ inputs.image-name }}
+      image-pack: ${{ inputs.image-pack }}
+      image-pack-tag: ${{ inputs.image-pack-tag }}
+      java-version: ${{ inputs.java-version }}
+      native: ${{ inputs.native }}
+      application-path: ${{ inputs.application-path }}
+      trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+      trivy-library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+      trivy-library-severity: ${{ inputs.trivy-library-severity }}
+      trivy-os-disable-scan: ${{ inputs.trivy-os-disable-scan }}
+      trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
+      trivy-os-severity: ${{ inputs.trivy-os-severity }}
+      trivy-version: ${{ inputs.trivy-version }}
+    secrets: inherit
 
-  # call-auto-merge:
-  #   name: Call auto-merge
-  #   if: |
-  #     always() &&
-  #     inputs.enable-auto-merge-dependabot == true &&
-  #     (needs.build-and-test-java.result == 'success' || needs.build-and-test-java.result == 'skipped') &&
-  #     (needs.call-spring-boot-container-scan.result == 'success' || needs.call-spring-boot-container-scan.result == 'skipped') &&
-  #     (needs.call-quarkus-container-scan.result == 'success' || needs.call-quarkus-container-scan.result == 'skipped')
-  #   needs:
-  #     [
-  #       build-and-test-java,
-  #       call-spring-boot-container-scan,
-  #       call-quarkus-container-scan,
-  #     ]
-  #   uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@main
-  #   permissions:
-  #     contents: write
-  #     pull-requests: write
-  #   with:
-  #     update-types: ${{ inputs.auto-merge-types }}
-  #   secrets: inherit
+  call-auto-merge:
+    name: Call auto-merge
+    if: |
+      always() &&
+      inputs.enable-auto-merge-dependabot == true &&
+      (needs.build-and-test-java.result == 'success' || needs.build-and-test-java.result == 'skipped') &&
+      (needs.call-spring-boot-container-scan.result == 'success' || needs.call-spring-boot-container-scan.result == 'skipped') &&
+      (needs.call-quarkus-container-scan.result == 'success' || needs.call-quarkus-container-scan.result == 'skipped')
+    needs:
+      [
+        build-and-test-java,
+        call-spring-boot-container-scan,
+        call-quarkus-container-scan,
+      ]
+    uses: felleslosninger/github-workflows/.github/workflows/misc-approve-and-merge-dependabot-pr.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      update-types: ${{ inputs.auto-merge-types }}
+    secrets: inherit
 
-  # # PS! At some point, after GitHub made changes to how Dependabot permissions
-  # # worked, this step was skipped automatically. The Platform team thinks this
-  # # is actually good, as we do not really want to support this behaviour because
-  # # of supply-chain security concerns. It means that the Platform team do not
-  # # want to encourage automatic image deployment of automatically merged
-  # # Dependabot PRs without human oversight. This step will probably be removed
-  # # in the future, but for now it is left in the workflow until it has been
-  # # discussed further.
-  # call-build-image:
-  #   name: Call build image
-  #   if: needs.call-auto-merge.outputs.merged == 'true'
-  #   runs-on: ubuntu-latest
-  #   needs: call-auto-merge
-  #   steps:
-  #     - name: call-build-publish-image
-  #       uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
-  #       with:
-  #         event-type: build-publish-image
+  # PS! At some point, after GitHub made changes to how Dependabot permissions
+  # worked, this step was skipped automatically. The Platform team thinks this
+  # is actually good, as we do not really want to support this behaviour because
+  # of supply-chain security concerns. It means that the Platform team do not
+  # want to encourage automatic image deployment of automatically merged
+  # Dependabot PRs without human oversight. This step will probably be removed
+  # in the future, but for now it is left in the workflow until it has been
+  # discussed further.
+  call-build-image:
+    name: Call build image
+    if: needs.call-auto-merge.outputs.merged == 'true'
+    runs-on: ubuntu-latest
+    needs: call-auto-merge
+    steps:
+      - name: call-build-publish-image
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # pin@v4.0.1
+        with:
+          event-type: build-publish-image


### PR DESCRIPTION
This PR adds a new composite action for validating PR titles. This was created to replace

- https://github.com/felleslosninger/github-actions/tree/main/validate-pull-request-title (27k lines of JavaScript 🤯)
- https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-maven-build-lib.yml#L89 (hardcoded GitHub script)
- https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-maven-build.yml#L90 (hardcoded GitHub script)

This is now written in Bash to be more easily maintained in this repository. It has been created in a way so that no overrides are necessary from the application repositories using the PR checks workflow (or the deprecated Maven build workflows). This means all inputs are empty strings, and that the actual defaults are set within the Bash script. By doing it this way, we do not need to maintain input defaults in both the action and in PR checks. If empty defaults are detected, we have fallbacks within the Bash script to do The Right Thing ™️. You can still disable the entire validation  by setting `enable-pr-title-verify` to `false` in your app repo.

As an example, if we need to allow another prefix, you update this in the `STANDARD_PREFIXES` variable within the Bash script. This should also make it easier for developers to contribute. 

---

Testing:

Most of the testing has been done in https://github.com/felleslosninger/plattform-test-app/pull/527.

---

Followup:

- Remove https://github.com/felleslosninger/github-actions/tree/main/validate-pull-request-title when this is merged 