### PR TITLE
PF-2468 Consolidate deploy lib workflows

### DIFF
--- a/.github/actions/trivy-sbom/action.yml
+++ b/.github/actions/trivy-sbom/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Skip Trivy setup if it has already been run in a previous step"
     default: "false"
     required: false
+  offline-scan:
+    description: "Resolve dependencies without calling remote repositories. Use ONLY when a prior step (e.g. 'mvn install') has populated the cache."
+    default: "false"
+    required: false
 
 runs:
   using: composite
@@ -83,6 +87,7 @@ runs:
       env:
         TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2,public.ecr.aws/aquasecurity/trivy-db:2
         TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-java-db:1
+        TRIVY_OFFLINE_SCAN: ${{ inputs.offline-scan }}
       with:
         scan-type: ${{ inputs.scan-type }}
         format: github

--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: When to fail the scan with library vulnerabilities
     default: "HIGH,CRITICAL"
     required: false
+  library-offline-scan:
+    description: "Resolve dependencies without calling remote repositories like Maven Central. Use ONLY when a prior step (e.g. 'mvn install') has populated the cache — otherwise the scan is silently incomplete."
+    default: "false"
+    required: false
   os-disable-scan:
     description: Disable OS scan
     default: "false"
@@ -149,6 +153,8 @@ runs:
         TRIVY_JAVA_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-java-db:1,public.ecr.aws/aquasecurity/trivy-java-db:1
         # Disable noisy VEX notice from the scan result
         TRIVY_DISABLE_VEX_NOTICE: "true"
+        # Resolve from local cache only to avoid Maven Central 429s; safe because a prior step warmed the cache.
+        TRIVY_OFFLINE_SCAN: ${{ inputs.library-offline-scan }}
       with:
         version: ${{ inputs.trivy-version }}
         scan-type: ${{ inputs.scan-type }}

--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -253,6 +253,7 @@ jobs:
       slack-channel-id: ${{ inputs.slack-channel-id }}
       cache-path: ${{ inputs.cache-path }}
       native: ${{ inputs.native }}
+      application-path: ${{ inputs.application-path }}
       container-registry: ${{ needs.input-checks.outputs.container-registry }}
       sp-container-registry-client-id: ${{ needs.input-checks.outputs.sp-container-registry-client-id }}
       trivy-library-disable-scan: ${{ inputs.trivy-library-disable-scan }}

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -198,7 +198,7 @@ jobs:
           TARGET_DIR="${APP_PATH:-.}"
           cd "$TARGET_DIR" || exit 1
 
-          MAVEN_ARGS=("-B" "deploy")
+          MAVEN_ARGS=("-B" "deploy" "-DskipTests")
 
           if [ -n "$PROFILE" ]; then
             MAVEN_ARGS+=("-P$PROFILE")

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -1,0 +1,249 @@
+# Workflow Name: Build and publish Maven library to GitHub packages
+#
+# Owner: Digdir Platform team / Digdir development teams
+#
+# Purpose:
+#   This workflow performs a Maven build of a Java library and publishes the
+#   built artifact to GitHub packages. It is the golden path for releasing
+#   Maven libraries and replaces both ci-maven-deploy.yml and
+#   ci-maven-install-deploy-lib.yml.
+#
+#   It supports projects with internal Maven dependencies (hosted in other
+#   private GitHub Packages repositories) by reading dependencies with the
+#   'GH_PACKAGES_READ_USER' / 'GH_PACKAGES_READ_PAT' secrets. By default
+#   'enable-maven-install' is true, so 'mvn clean install' runs before deploy to
+#   resolve and build internal dependencies locally first. Projects without
+#   internal dependencies can set 'enable-maven-install' to false for the
+#   simpler build-and-deploy flow.
+#
+#   Flow:
+#     1. Checkout repository
+#     2. Set up JDK (reads dependencies with the GH_PACKAGES_READ_* secrets)
+#     3. Optionally set version with `mvn versions:set`
+#     4. Optionally run `mvn clean install` to resolve internal dependencies
+#        (when 'enable-maven-install' is true)
+#     5. Run Trivy vulnerability scanner ('fs' scan)
+#     6. Overwrite m2 settings to be allowed to publish to GitHub packages
+#     7. Deploy to Maven GitHub packages repository
+#     8. Run Trivy SBOM generation (resolves SBOM metadata for multi-module
+#        projects)
+#
+# Trigger:
+#   Triggered by workflow calls (workflow_call)
+#
+# Inputs:
+#   See input section
+#
+# Outputs:
+#   None
+
+name: Build and publish Maven library to GitHub packages
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      application-path:
+        description: Path to the application directory to scan with Trivy, relative to the repository root
+        default: "./"
+        required: false
+        type: string
+      artifact-name:
+        description: Override the artifact id used for SBOM generation. Defaults to the multi-module path or repository name
+        required: false
+        type: string
+      cache-path:
+        description: Path to cache dependencies, relative to the repository root
+        default: "**/pom.xml"
+        required: false
+        type: string
+      deployment-repository:
+        description: Set deployment repo
+        default: ""
+        required: false
+        type: string
+      fetch-depth:
+        description: Fetch depth for checkout
+        default: 1
+        required: false
+        type: number
+      java-distribution:
+        description: Java distribution to use
+        default: "liberica"
+        required: false
+        type: string
+      java-version:
+        description: Main version of java
+        default: "25"
+        required: false
+        type: string
+      package-version:
+        description: Version to use for maven package
+        default: ""
+        required: false
+        type: string
+      profile:
+        description: Maven profile to use
+        required: false
+        type: string
+      sbom-path:
+        description: Target directory for SBOM generation
+        required: false
+        type: string
+      trivy-library-disable-scan:
+        description: Disable Trivy library scan
+        type: boolean
+        required: false
+        default: false
+      trivy-library-ignore-unfixed:
+        description: Ignore unfixed vulnerabilities in Trivy library scan
+        type: boolean
+        required: false
+        default: true
+      trivy-library-severity:
+        description: When to fail the scan with Trivy library vulnerabilities
+        type: string
+        required: false
+        default: 'HIGH,CRITICAL'
+      trivy-version:
+        description: Version of Trivy to use for scanning
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  inputs-to-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write inputs to summary
+        uses: felleslosninger/github-workflows/.github/actions/json-to-summary@main
+        with:
+          json-payload: ${{ toJson(inputs) }}
+
+  build-publish-package:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+
+      - name: Set up JDK ${{ inputs.java-version }}
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        with:
+          distribution: "${{ inputs.java-distribution }}"
+          java-version: ${{ inputs.java-version }}
+          cache: maven
+          cache-dependency-path: ${{ inputs.cache-path }}
+          server-id: github
+          server-username: GH_PACKAGES_READ_USER
+          server-password: GH_PACKAGES_READ_PAT
+
+      - name: Set version
+        env:
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
+          PACKAGE_VERSION: ${{ inputs.package-version }}
+        run: |
+          if [ -n "$PACKAGE_VERSION" ]; then
+            mvn versions:set -B -DnewVersion="$PACKAGE_VERSION"
+            echo "- \`mvn versions\` was executed" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- \`mvn versions\` was not executed" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Maven install
+        env:
+          GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
+          GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
+          PROFILE: ${{ inputs.profile }}
+        run: |
+          if [ -n "$PROFILE" ]; then
+            mvn -B clean install --update-snapshots -P"$PROFILE"
+          else
+            mvn -B clean install --update-snapshots
+          fi
+
+      - name: Run Trivy vulnerability scanner (fs)
+        uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
+        with:
+          scan-type: "fs"
+          application-path: ${{ inputs.application-path }}
+          library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
+          library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
+          library-severity: ${{ inputs.trivy-library-severity }}
+          trivy-version: ${{ inputs.trivy-version }}
+
+      - name: Overwrite m2 settings to publish libs
+        env:
+          PUBLISH_ACTOR: ${{ github.actor }}
+          PUBLISH_TOKEN: ${{ github.token }}
+        run: |
+          echo "<settings><servers><server><id>github</id><username>${PUBLISH_ACTOR}</username><password>${PUBLISH_TOKEN}</password></server></servers></settings>" > ~/.m2/settings.xml
+
+      - name: Maven deploy
+        env:
+          PROFILE: ${{ inputs.profile }}
+          DEPLOYMENT_REPO: ${{ inputs.deployment-repository }}
+          APP_PATH: ${{ inputs.application-path }}
+        run: |
+          TARGET_DIR="${APP_PATH:-.}"
+          cd "$TARGET_DIR" || exit 1
+
+          MAVEN_ARGS=("-B" "deploy")
+
+          if [ -n "$PROFILE" ]; then
+            MAVEN_ARGS+=("-P$PROFILE")
+          fi
+
+          if [ -n "$DEPLOYMENT_REPO" ]; then
+            MAVEN_ARGS+=("-DaltDeploymentRepository=github::https://maven.pkg.github.com/$DEPLOYMENT_REPO")
+          fi
+
+          mvn "${MAVEN_ARGS[@]}"
+
+      # This is a temporary step specifically for handling multi-module
+      # repositories with Trivy SBOM generation for Maven artifacts. We strip
+      # 'target' and slashes to sanitize the path for the new SBOM generation
+      # (Anchore previously used the 'sbom-path' directly, but this caused
+      # issues with Trivy scan and multi-module projects where the path included
+      # 'target' directories).
+      - name: Resolve SBOM Metadata
+        id: sbom-meta
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          SBOM_PATH: ${{ inputs.sbom-path }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          APP_PATH: ${{ inputs.application-path }}
+        run: |
+          # Default to 'application-path' or root if 'sbom-path' is empty
+          RAW_PATH="${SBOM_PATH:-${APP_PATH:-.}}"
+          CLEAN_PATH=$(echo "$RAW_PATH" | sed 's/\/target$//' | sed 's/^\.\///' | sed 's/\/$//')
+
+          # Resolve the Artifact ID
+          if [ -n "$ARTIFACT_NAME" ]; then
+            # Use 'artifact-name' if provided
+            ARTIFACT_ID="$ARTIFACT_NAME"
+          elif [ "$CLEAN_PATH" != "." ] && [ -n "$CLEAN_PATH" ]; then
+            # If it's a multi-module path, use the folder name
+            ARTIFACT_ID="$CLEAN_PATH"
+          else
+            # Fallback to repository name
+            ARTIFACT_ID="$REPO_NAME"
+          fi
+
+          echo "path=${CLEAN_PATH:-.}" >> "$GITHUB_OUTPUT"
+          echo "id=$ARTIFACT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Run Trivy SBOM generation
+        uses: felleslosninger/github-workflows/.github/actions/trivy-sbom@main
+        with:
+          scan-type: fs
+          artifact-id: ${{ steps.sbom-meta.outputs.id }}
+          application-path: ${{ steps.sbom-meta.outputs.path }}
+          version: ${{ inputs.package-version }}
+          # This is already done in Trivy vuln scan step
+          skip-setup: true

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -5,7 +5,7 @@
 # Purpose:
 #   This workflow performs a Maven build of a Java library and publishes the
 #   built artifact to GitHub packages. It is the golden path for releasing
-#   Maven libraries and replaces both ci-maven-deploy.yml and
+#   Maven libraries and is intended to replace both ci-maven-deploy.yml and
 #   ci-maven-install-deploy-lib.yml.
 #
 #   It supports projects with internal Maven dependencies (hosted in other

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -47,7 +47,7 @@ on:
   workflow_call:
     inputs:
       application-path:
-        description: Path to the application directory to scan with Trivy, relative to the repository root
+        description: Path to the Maven project directory (also used as the Trivy scan root), relative to the repository root
         default: "./"
         required: false
         type: string

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -1,6 +1,6 @@
 # Workflow Name: Build and publish Maven library to GitHub packages
 #
-# Owner: Digdir Platform team / Digdir development teams
+# Owner: Digdir Platform team 
 #
 # Purpose:
 #   This workflow performs a Maven build of a Java library and publishes the
@@ -10,19 +10,21 @@
 #
 #   It supports projects with internal Maven dependencies (hosted in other
 #   private GitHub Packages repositories) by reading dependencies with the
-#   'GH_PACKAGES_READ_USER' / 'GH_PACKAGES_READ_PAT' secrets. By default
-#   'enable-maven-install' is true, so 'mvn clean install' runs before deploy to
-#   resolve and build internal dependencies locally first. Projects without
-#   internal dependencies can set 'enable-maven-install' to false for the
-#   simpler build-and-deploy flow.
+#   'GH_PACKAGES_READ_USER' / 'GH_PACKAGES_READ_PAT' secrets.
+#
+#   'mvn clean install' always runs BEFORE the Trivy filesystem scan. This is
+#   required so that Maven resolves and builds the full dependency tree
+#   (including internal and transitive dependencies) locally first; the Trivy
+#   'fs' scan can then detect CVEs across the resolved dependencies rather than
+#   from a static pom.xml-only analysis.
 #
 #   Flow:
 #     1. Checkout repository
 #     2. Set up JDK (reads dependencies with the GH_PACKAGES_READ_* secrets)
 #     3. Optionally set version with `mvn versions:set`
-#     4. Optionally run `mvn clean install` to resolve internal dependencies
-#        (when 'enable-maven-install' is true)
-#     5. Run Trivy vulnerability scanner ('fs' scan)
+#     4. Run `mvn clean install` to resolve and build the dependency tree before
+#        scanning
+#     5. Run Trivy vulnerability scanner ('fs' scan) over the resolved project
 #     6. Overwrite m2 settings to be allowed to publish to GitHub packages
 #     7. Deploy to Maven GitHub packages repository
 #     8. Run Trivy SBOM generation (resolves SBOM metadata for multi-module

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -51,10 +51,6 @@ on:
         default: "./"
         required: false
         type: string
-      artifact-name:
-        description: Override the artifact id used for SBOM generation. Defaults to the multi-module path or repository name
-        required: false
-        type: string
       cache-path:
         description: Path to cache dependencies, relative to the repository root
         default: "**/pom.xml"
@@ -80,13 +76,17 @@ on:
         default: "25"
         required: false
         type: string
+      maven-profile:
+        description: Maven profile to use
+        required: false
+        type: string
       package-version:
         description: Version to use for maven package
         default: ""
         required: false
         type: string
-      profile:
-        description: Maven profile to use
+      sbom-artifact-id:
+        description: Override the artifact id used for SBOM generation. Defaults to the multi-module path or repository name
         required: false
         type: string
       sbom-path:
@@ -161,7 +161,7 @@ jobs:
         env:
           GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
           GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
-          PROFILE: ${{ inputs.profile }}
+          PROFILE: ${{ inputs.maven-profile }}
         run: |
           if [ -n "$PROFILE" ]; then
             mvn -B clean install --update-snapshots -P"$PROFILE"
@@ -189,7 +189,7 @@ jobs:
 
       - name: Maven deploy
         env:
-          PROFILE: ${{ inputs.profile }}
+          PROFILE: ${{ inputs.maven-profile }}
           DEPLOYMENT_REPO: ${{ inputs.deployment-repository }}
           APP_PATH: ${{ inputs.application-path }}
         run: |
@@ -217,7 +217,7 @@ jobs:
       - name: Resolve SBOM Metadata
         id: sbom-meta
         env:
-          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          SBOM_ARTIFACT_ID: ${{ inputs.sbom-artifact-id }}
           SBOM_PATH: ${{ inputs.sbom-path }}
           REPO_NAME: ${{ github.event.repository.name }}
           APP_PATH: ${{ inputs.application-path }}
@@ -227,9 +227,9 @@ jobs:
           CLEAN_PATH=$(echo "$RAW_PATH" | sed 's/\/target$//' | sed 's/^\.\///' | sed 's/\/$//')
 
           # Resolve the Artifact ID
-          if [ -n "$ARTIFACT_NAME" ]; then
-            # Use 'artifact-name' if provided
-            ARTIFACT_ID="$ARTIFACT_NAME"
+          if [ -n "$SBOM_ARTIFACT_ID" ]; then
+            # Use 'sbom-artifact-id' if provided
+            ARTIFACT_ID="$SBOM_ARTIFACT_ID"
           elif [ "$CLEAN_PATH" != "." ] && [ -n "$CLEAN_PATH" ]; then
             # If it's a multi-module path, use the folder name
             ARTIFACT_ID="$CLEAN_PATH"

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -23,10 +23,14 @@
 #     2. Set up JDK (reads dependencies with the GH_PACKAGES_READ_* secrets)
 #     3. Optionally set version with `mvn versions:set`
 #     4. Run `mvn clean install` to resolve and build the dependency tree before
-#        scanning
+#        scanning. For multi-module projects, set the 'module-name' input to
+#        scope the build to a single module with `-pl <module-name> -am` (the
+#        module plus its upstream reactor dependencies); otherwise the full
+#        reactor is built.
 #     5. Run Trivy vulnerability scanner ('fs' scan) over the resolved project
 #     6. Overwrite m2 settings to be allowed to publish to GitHub packages
-#     7. Deploy to Maven GitHub packages repository
+#     7. Deploy to Maven GitHub packages repository (only the selected module
+#        when 'module-name' is set, otherwise from 'application-path')
 #     8. Run Trivy SBOM generation (resolves SBOM metadata for multi-module
 #        projects)
 #
@@ -78,6 +82,10 @@ on:
         type: string
       maven-profile:
         description: Maven profile to use
+        required: false
+        type: string
+      module-name:
+        description: Name of the Maven module to build and publish, for multi-module reactor projects. When set, the build is scoped with `-pl <module-name> -am` so the module and its upstream reactor dependencies are built (in order) and only this module is deployed. When empty, the full reactor is built and deployed from 'application-path'.
         required: false
         type: string
       package-version:
@@ -162,12 +170,23 @@ jobs:
           GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
           GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           PROFILE: ${{ inputs.maven-profile }}
+          MODULE_NAME: ${{ inputs.module-name }}
         run: |
-          if [ -n "$PROFILE" ]; then
-            mvn -B clean install --update-snapshots -P"$PROFILE"
-          else
-            mvn -B clean install --update-snapshots
+          MAVEN_ARGS=("-B" "clean" "install" "--update-snapshots")
+
+          if [ -n "$MODULE_NAME" ]; then
+            # Multi-module: build only this module and its upstream reactor
+            # dependencies (in order). Runs from the reactor root so the
+            # reactor context is intact; a plain 'install' inside the module
+            # directory would not build the sibling modules it depends on.
+            MAVEN_ARGS+=("-pl" "$MODULE_NAME" "-am")
           fi
+
+          if [ -n "$PROFILE" ]; then
+            MAVEN_ARGS+=("-P$PROFILE")
+          fi
+
+          mvn "${MAVEN_ARGS[@]}"
 
       - name: Run Trivy vulnerability scanner (fs)
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
@@ -194,11 +213,22 @@ jobs:
           PROFILE: ${{ inputs.maven-profile }}
           DEPLOYMENT_REPO: ${{ inputs.deployment-repository }}
           APP_PATH: ${{ inputs.application-path }}
+          MODULE_NAME: ${{ inputs.module-name }}
         run: |
-          TARGET_DIR="${APP_PATH:-.}"
-          cd "$TARGET_DIR" || exit 1
-
           MAVEN_ARGS=("-B" "deploy" "-DskipTests")
+
+          if [ -n "$MODULE_NAME" ]; then
+            # Multi-module: deploy only the selected module, from the reactor
+            # root. No '-am' here on purpose — upstream reactor dependencies
+            # were already built into ~/.m2 by the 'Maven install' step and are
+            # published by their own workflow call, so we publish this module
+            # only.
+            MAVEN_ARGS+=("-pl" "$MODULE_NAME")
+          else
+            # Single-module / whole-reactor: deploy from the project directory.
+            TARGET_DIR="${APP_PATH:-.}"
+            cd "$TARGET_DIR" || exit 1
+          fi
 
           if [ -n "$PROFILE" ]; then
             MAVEN_ARGS+=("-P$PROFILE")

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -30,7 +30,8 @@
 #     5. Run Trivy vulnerability scanner ('fs' scan) over the resolved project
 #     6. Overwrite m2 settings to be allowed to publish to GitHub packages
 #     7. Deploy to Maven GitHub packages repository (only the selected module
-#        when 'module-name' is set, otherwise from 'application-path')
+#        when 'module-name' is set, otherwise the full reactor from the
+#        repository root)
 #     8. Run Trivy SBOM generation (resolves SBOM metadata for multi-module
 #        projects)
 #
@@ -50,11 +51,6 @@ permissions: {}
 on:
   workflow_call:
     inputs:
-      application-path:
-        description: Path to the Maven project directory (also used as the Trivy scan root), relative to the repository root
-        default: "./"
-        required: false
-        type: string
       cache-path:
         description: Path to cache dependencies, relative to the repository root
         default: "**/pom.xml"
@@ -85,7 +81,7 @@ on:
         required: false
         type: string
       module-name:
-        description: Name of the Maven module to build and publish, for multi-module reactor projects. When set, the build is scoped with `-pl <module-name> -am` so the module and its upstream reactor dependencies are built (in order) and only this module is deployed. When empty, the full reactor is built and deployed from 'application-path'.
+        description: Name of the Maven module to build and publish, for multi-module reactor projects. When set, the build is scoped with `-pl <module-name> -am` so the module and its upstream reactor dependencies are built (in order) and only this module is deployed. When empty, the full reactor is built and deployed from the repository root.
         required: false
         type: string
       package-version:
@@ -192,7 +188,6 @@ jobs:
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           scan-type: "fs"
-          application-path: ${{ inputs.application-path }}
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
@@ -212,7 +207,6 @@ jobs:
         env:
           PROFILE: ${{ inputs.maven-profile }}
           DEPLOYMENT_REPO: ${{ inputs.deployment-repository }}
-          APP_PATH: ${{ inputs.application-path }}
           MODULE_NAME: ${{ inputs.module-name }}
         run: |
           MAVEN_ARGS=("-B" "deploy" "-DskipTests")
@@ -224,10 +218,6 @@ jobs:
             # published by their own workflow call, so we publish this module
             # only.
             MAVEN_ARGS+=("-pl" "$MODULE_NAME")
-          else
-            # Single-module / whole-reactor: deploy from the project directory.
-            TARGET_DIR="${APP_PATH:-.}"
-            cd "$TARGET_DIR" || exit 1
           fi
 
           if [ -n "$PROFILE" ]; then
@@ -252,10 +242,9 @@ jobs:
           SBOM_ARTIFACT_ID: ${{ inputs.sbom-artifact-id }}
           SBOM_PATH: ${{ inputs.sbom-path }}
           REPO_NAME: ${{ github.event.repository.name }}
-          APP_PATH: ${{ inputs.application-path }}
         run: |
-          # Default to 'application-path' or root if 'sbom-path' is empty
-          RAW_PATH="${SBOM_PATH:-${APP_PATH:-.}}"
+          # Default to the repository root if 'sbom-path' is empty
+          RAW_PATH="${SBOM_PATH:-.}"
           CLEAN_PATH=$(echo "$RAW_PATH" | sed 's/\/target$//' | sed 's/^\.\///' | sed 's/\/$//')
 
           # Resolve the Artifact ID

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -178,6 +178,8 @@ jobs:
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
           trivy-version: ${{ inputs.trivy-version }}
+          # Cache is warmed by the preceding 'mvn clean install'
+          library-offline-scan: true
 
       - name: Overwrite m2 settings to publish libs
         env:
@@ -250,3 +252,5 @@ jobs:
           version: ${{ inputs.package-version }}
           # This is already done in Trivy vuln scan step
           skip-setup: true
+          # Cache is warmed by the preceding 'mvn clean install'
+          offline-scan: true

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -191,6 +191,10 @@ jobs:
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           scan-type: "fs"
+          # Scope the scan to the built module (its upstream reactor deps are
+          # resolved from the warm ~/.m2 via the module pom); repo root when
+          # 'module-name' is unset.
+          application-path: ${{ inputs.module-name || './' }}
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -152,9 +152,9 @@ jobs:
         run: |
           if [ -n "$PACKAGE_VERSION" ]; then
             mvn versions:set -B -DnewVersion="$PACKAGE_VERSION"
-            echo "- \`mvn versions\` was executed" >> "$GITHUB_STEP_SUMMARY"
+            echo "- \`mvn versions:set\` was executed" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- \`mvn versions\` was not executed" >> "$GITHUB_STEP_SUMMARY"
+            echo "- \`mvn versions:set\` was not executed" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Maven install
@@ -184,6 +184,7 @@ jobs:
           PUBLISH_ACTOR: ${{ github.actor }}
           PUBLISH_TOKEN: ${{ github.token }}
         run: |
+          mkdir -p ~/.m2
           echo "<settings><servers><server><id>github</id><username>${PUBLISH_ACTOR}</username><password>${PUBLISH_TOKEN}</password></server></servers></settings>" > ~/.m2/settings.xml
 
       - name: Maven deploy

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -26,7 +26,10 @@
 #        scanning. For multi-module projects, set the 'module-name' input to
 #        scope the build to a single module with `-pl <module-name> -am` (the
 #        module plus its upstream reactor dependencies); otherwise the full
-#        reactor is built.
+#        reactor is built. 'module-name' MUST be the module's directory path
+#        relative to the reactor root (e.g. 'payment/api'), NOT the Maven
+#        coordinate form (`:artifactId` or `groupId:artifactId`); the Trivy scan
+#        and SBOM steps derive filesystem paths from it.
 #     5. Run Trivy vulnerability scanner ('fs' scan) over the resolved project
 #     6. Overwrite m2 settings to be allowed to publish to GitHub packages
 #     7. Deploy to Maven GitHub packages repository (only the selected module
@@ -81,7 +84,7 @@ on:
         required: false
         type: string
       module-name:
-        description: Name of the Maven module to build and publish, for multi-module reactor projects. When set, the build is scoped with `-pl <module-name> -am` so the module and its upstream reactor dependencies are built (in order) and only this module is deployed. When empty, the full reactor is built and deployed from the repository root.
+        description: Directory path of the Maven module to build and publish, relative to the reactor root (e.g. 'payment/api'), for multi-module reactor projects. Must be the module directory path, NOT the Maven coordinate form (`:artifactId` or `groupId:artifactId`), because the Trivy scan and SBOM steps derive filesystem paths from it. When set, the build is scoped with `-pl <module-name> -am` so the module and its upstream reactor dependencies are built (in order) and only this module is deployed. When empty, the full reactor is built and deployed from the repository root.
         required: false
         type: string
       package-version:
@@ -242,9 +245,12 @@ jobs:
           SBOM_ARTIFACT_ID: ${{ inputs.sbom-artifact-id }}
           SBOM_PATH: ${{ inputs.sbom-path }}
           REPO_NAME: ${{ github.event.repository.name }}
+          MODULE_NAME: ${{ inputs.module-name }}
         run: |
-          # Default to the repository root if 'sbom-path' is empty
-          RAW_PATH="${SBOM_PATH:-.}"
+          # Default to the selected module directory (so multi-module SBOMs keep
+          # a per-module artifact id), then the repository root, if 'sbom-path'
+          # is empty
+          RAW_PATH="${SBOM_PATH:-${MODULE_NAME:-.}}"
           CLEAN_PATH=$(echo "$RAW_PATH" | sed 's/\/target$//' | sed 's/^\.\///' | sed 's/\/$//')
 
           # Resolve the Artifact ID

--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -2,6 +2,11 @@
 #
 # Owner: Digdir Platform team / Digdir development teams
 #
+# DEPRECATED:
+#   This workflow is deprecated. Use the golden path
+#   ci-build-publish-lib.yml instead, which covers both projects with and
+#   without internal Maven dependencies. Please migrate.
+#
 # Purpose:
 #   This workflow is designed to perform a Maven build of a Java application,
 #   and publish the built artifact to GitHub packages. It should be used when

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -2,6 +2,11 @@
 #
 # Owner: Digdir Platform team / Digdir development teams
 #
+# DEPRECATED:
+#   This workflow is deprecated. Use the golden path
+#   ci-build-publish-lib.yml instead, which covers both projects with and
+#   without internal Maven dependencies. Please migrate.
+#
 # Purpose:
 #   This workflow is designed to perform a Maven build of a Java application,
 #   and publish the built artifact to GitHub packages. It should be used when

--- a/.github/workflows/ci-pr-checks-lib.yml
+++ b/.github/workflows/ci-pr-checks-lib.yml
@@ -207,6 +207,8 @@ jobs:
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
           trivy-version: ${{ inputs.trivy-version }}
+          # Cache is warmed by the preceding 'mvn' run (default lifecycle: install)
+          library-offline-scan: true
 
       - name: Upload artifact
         if: |

--- a/.github/workflows/ci-pr-checks-lib.yml
+++ b/.github/workflows/ci-pr-checks-lib.yml
@@ -9,7 +9,7 @@
 #   Flow:
 #     1. Verifies PR title
 #     2. Builds and tests from root pom with mvn lifecycle chosen in
-#        inputs (default: test).
+#        inputs (default: install).
 #     3. Scans with Trivy FS scan to fail fast on library vulnerabilities
 #     4. Uploads build artifact (optional)
 #     5. Auto-merges Dependabot PRs (optional)

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -92,6 +92,11 @@ on:
         required: false
         type: boolean
         default: false
+      application-path:
+        description: Path to the application directory to scan with Trivy, relative to the repository root
+        default: "./"
+        required: false
+        type: string
       container-registry:
         description: Azure Container Registry name
         default: "creiddev.azurecr.io"
@@ -264,6 +269,7 @@ jobs:
         uses: felleslosninger/github-workflows/.github/actions/trivy-scan@main
         with:
           image-ref: ${{ steps.image-metadata.outputs.image-name }}:${{ steps.image-metadata.outputs.image-tag }}
+          application-path: ${{ inputs.application-path }}
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ for more information.
 
 Workflows for building and publishing Maven libraries after commits to main
 
-- [ci-maven-deploy.yml](.github/workflows/ci-maven-deploy.yml): For projects
-  without internal Maven dependencies
-- [ci-maven-install-deploy-lib.yml](.github/workflows/ci-maven-install-deploy-lib.yml):
-  For projects with internal dependencies
+- [ci-build-publish-lib.yml](.github/workflows/ci-build-publish-lib.yml): The
+  golden path for building and publishing Maven libraries. Use this for all
+  projects, with or without internal Maven dependencies. It replaces the
+  deprecated `ci-maven-deploy.yml` and `ci-maven-install-deploy-lib.yml`.
 
 Check out the [internal usage
 docs](https://paotvers.io/docs/default/Domain/application-platform/Application/Repository/workflows/release-artifact/)
@@ -138,6 +138,14 @@ functionality should be covered by our golden path
 
 - [ci-maven-build.yml](.github/workflows/ci-maven-build.yml)
 - [ci-maven-build-lib.yml](.github/workflows/ci-maven-build-lib.yml)
+
+The following build-and-publish workflows are deprecated and replaced by the
+golden path [ci-build-publish-lib.yml](.github/workflows/ci-build-publish-lib.yml)
+workflow, which covers both projects with and without internal Maven
+dependencies. Migrate to it.
+
+- [ci-maven-deploy.yml](.github/workflows/ci-maven-deploy.yml)
+- [ci-maven-install-deploy-lib.yml](.github/workflows/ci-maven-install-deploy-lib.yml)
 
 ### Custom workflows
 


### PR DESCRIPTION
Merges `ci-maven-deploy.yml` and `ci-maven-install-deploy-lib.yml` into one
workflow, `ci-build-publish-lib.yml`, for building a Maven lib and publishing it
to GitHub Packages.

For multi-module repos there's a new optional `module-name` input: set it and
the build/deploy is scoped to that module (`-pl <module-name> -am`), leave it out
and the whole reactor is built and deployed. It has to be the module's directory
path (e.g. `payment/api`), since the Trivy/SBOM steps use it as a path. Everything
runs from the reactor root so cross-module deps resolve. Dropped the old
`application-path` input, and deploy now skips tests (they already ran in install).

Migration: point callers at `ci-build-publish-lib.yml` instead of the old two
(one call per published module with `module-name`). The old workflows are marked
deprecated in the README but left in place for now.