### PR TITLE
PF-2474  Parameterizing the Docker build context

### DIFF
--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -62,6 +62,11 @@ on:
         default: "./"
         required: false
         type: string
+      docker-build-context:
+        description: Docker build context directory (resolves COPY/ADD paths). Defaults to the repository root.
+        default: "."
+        required: false
+        type: string
       add-git-package-token:
         description: Adds GIT_PACKAGE_TOKEN build argument for Docker
         required: false
@@ -154,6 +159,7 @@ jobs:
       - name: Build image
         env:
           APP_PATH: ${{ inputs.application-path }}
+          BUILD_CONTEXT: ${{ inputs.docker-build-context }}
           IMAGE_NAME: ${{ steps.image-metadata.outputs.image-name }}
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
           ADD_TOKEN: ${{ inputs.add-git-package-token }}
@@ -162,7 +168,7 @@ jobs:
           if [ "$ADD_TOKEN" = "true" ]; then
             docker build --tag "$IMAGE_NAME:$IMAGE_TAG" --file docker/Dockerfile --build-arg GIT_PACKAGE_TOKEN="$GITHUB_TOKEN" .
           else
-            docker build --tag "$IMAGE_NAME:$IMAGE_TAG" --file "$APP_PATH/Dockerfile" .
+            docker build --tag "$IMAGE_NAME:$IMAGE_TAG" --file "$APP_PATH/Dockerfile" "$BUILD_CONTEXT"
           fi
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -166,7 +166,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "$ADD_TOKEN" = "true" ]; then
-            docker build --tag "$IMAGE_NAME:$IMAGE_TAG" --file docker/Dockerfile --build-arg GIT_PACKAGE_TOKEN="$GITHUB_TOKEN" .
+            docker build --tag "$IMAGE_NAME:$IMAGE_TAG" --file docker/Dockerfile --build-arg GIT_PACKAGE_TOKEN="$GITHUB_TOKEN" "$BUILD_CONTEXT"
           else
             docker build --tag "$IMAGE_NAME:$IMAGE_TAG" --file "$APP_PATH/Dockerfile" "$BUILD_CONTEXT"
           fi


### PR DESCRIPTION
TL;DR:

einnsyn er avhengig av å sende med riktig context til docker build, se feil:
https://github.com/felleslosninger/ein-core/actions/runs/27827836322/job/82356687938

Årsaken er at når context bruker "." altså root, der dockerfile ligger, får den ikke med seg filene den trenger under: https://github.com/felleslosninger/ein-core/tree/main/docker/forward-proxy

Failed [run](https://github.com/felleslosninger/ein-core/actions/runs/27827836322/job/82356687938) triggering the need for this change
Successful [test](https://github.com/felleslosninger/ein-core/actions/runs/28014907466/job/82916730911) med docker-build-context
Successful [test](https://github.com/felleslosninger/ein-core/actions/runs/28015320162/job/82918652885) uten docker-build-context

____
Vi forbereder kyverno policy som enforcer image signatur og provenance (verify-image-and-slsa-provenance. Når enforca, så tillater clusteret bare container images signert av en godkjent workflow kjørt fra main. Dersom signert fra workflow med andre refs vil policy rejecte signaturen til imaget.


einnsyn sin forward-proxy, nginx and varnish images (bygges i felleslosninger/ein-core via deploy-forward-proxy.yml, deploy-nginx.yml, deploy-varnish.yml) caller shared build/sign workflow fra branch:
uses: felleslosninger/github-workflows/.github/workflows/ci-docker-build-publish-image.yml@einnsyn-docker-build

Dette forårsaker at valideringen feiler. Ved forsøk på å bytte til main versjon av ci-docker-build-publish-image.yml, så feiler det pga docker-build-context, default i dag bruker dette

docker build --file "$APP_PATH/Dockerfile" .

Ettersom contexten er hardkodet (.), men einnsyn sin Dockerfiles COPY filer sammen med dockerfile (docker/varnish/: COPY default.vcl /etc/config/, forward-proxy: COPY healthcheck.sh …). Med context på  repo root, finner ikke COPY filene og bygget filet — Testet av @Håvard Tørresen . Dette er årsaken til at einnsyn-docker-build branchen eksisterer.