### PR TITLE
PF-2490 Implement and configure CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# CODEOWNERS — CI/CD repository owned by the Digdir Platform team.
+#
+# Purpose: this repo holds the Platform team's shared CI/CD building blocks
+# (reusable workflows / composite actions). Contributions from other teams are
+# welcome and encouraged, but every change merged to `main` must carry a final
+# review from the Platform team. Combined with the GitHub ruleset option
+# "Require review from Code Owners", this stops a change from being approved and
+# merged entirely within the contributing team, without Platform-team sign-off.
+#
+# Reasoning & how-to: https://paotvers.io/docs/default/Domain/application-platform/Github/Code-owners/
+# Syntax reference:    https://docs.github.com/articles/about-code-owners
+#
+# How to extend this file:
+#   - The LAST matching pattern wins, so put more specific rules further down.
+#   - Add new path-specific rules in the "Path-specific owners" section below.
+#   - Keep the CODEOWNERS self-protect rule at the very bottom.
+
+# Default owner for everything in this repository.
+* @felleslosninger/plattform
+
+# --- Path-specific owners ---------------------------------------------------
+# Add new rules here to give another team ownership of a path. Each rule
+# overrides the default owner above for matching files. Example:
+#   /path/to/dir/   @felleslosninger/some-team
+# ---------------------------------------------------------------------------
+
+# Guard the governance file itself. Keep this as the last rule so that no rule
+# added above can accidentally remove Platform-team ownership of CODEOWNERS.
+/.github/CODEOWNERS @felleslosninger/plattform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,18 @@
 # Add new rules here to give another team ownership of a path. Each rule
 # overrides the default owner above for matching files. Example:
 #   /path/to/dir/   @felleslosninger/some-team
+#
+# Co-owned with the development teams (@felleslosninger/pipeline-owners)
+# Should reflect the "Owner:" annotations in docs of these files.
+# Both teams are listed so that a review from either team can approve changes
+# to these paths.
+/.github/actions/validate-pr-title/                  @felleslosninger/plattform @felleslosninger/pipeline-owners
+/.github/workflows/ci-maven-build.yml                @felleslosninger/plattform @felleslosninger/pipeline-owners
+/.github/workflows/ci-maven-build-lib.yml            @felleslosninger/plattform @felleslosninger/pipeline-owners
+/.github/workflows/ci-maven-deploy.yml               @felleslosninger/plattform @felleslosninger/pipeline-owners
+/.github/workflows/ci-maven-install-deploy-lib.yml   @felleslosninger/plattform @felleslosninger/pipeline-owners
+/.github/workflows/misc-publish-dev-docker.yml       @felleslosninger/plattform @felleslosninger/pipeline-owners
+/.github/workflows/on-pr-label.yml                   @felleslosninger/plattform @felleslosninger/pipeline-owners
 # ---------------------------------------------------------------------------
 
 # Guard the governance file itself. Keep this as the last rule so that no rule


### PR DESCRIPTION
See [Jira task](https://digdir.atlassian.net/browse/PF-2490).

In regards to Pipeline-harmonisering project Action Point 2: Se på CODEOWNERS i github-workflows:
[Slack Thread](https://digdir.slack.com/archives/C0B5QLATB47/p1780663627238379)

This is first draft to implement and configure CODEOWNERS in github-workflows repository.
The change will make the @felleslosninger/plattform automatically assigned as reviewers, but will not block any PRs from being merged until 'Require review from Code Owners' is enforced in the branch ruleset.