### PR TITLE
PF-2303 Consolidate Kustomize version 

### DIFF
--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -72,7 +72,7 @@ on:
       # Default should follow ArgoCD version
       kustomize-version:
         required: false
-        default: 5.8.1
+        default: ''
         type: string
       lifecycle:
         description: Lifecycle environment to determine container registry to publish to. Supported values are 'deployment' and 'development'. This will determine the container registry and credentials used for publishing the image

--- a/.github/workflows/ci-call-update-image.yml
+++ b/.github/workflows/ci-call-update-image.yml
@@ -72,7 +72,7 @@ on:
       # Default should follow ArgoCD version
       kustomize-version:
         required: false
-        default: 5.4.3
+        default: 5.8.1
         type: string
       lifecycle:
         description: Lifecycle environment to determine container registry to publish to. Supported values are 'deployment' and 'development'. This will determine the container registry and credentials used for publishing the image


### PR DESCRIPTION
**Summary**
Removes hardcoded Kustomize version default so it is inherited from kustomize-setup/action.yml in github-workflows-internal.

Companion PR in github-workflows-internal: [#198](https://github.com/felleslosninger/github-workflows-internal/pull/198)

**Test plan**
Trigger an update-version flow and verify the pipeline runs with Kustomize 5.8.1
This has been tested, check [PR-198](https://github.com/felleslosninger/github-workflows-internal/pull/198) for details.