### PR TITLE
Pf 2541 test workflow dependabot version bumps

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -207,7 +207,7 @@ jobs:
   run-spring-boot-build:
     needs: input-checks
     if: inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-build-publish-image.yml@PF-2541-test-workflow-dependabot-version-bumps
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -136,7 +136,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -141,7 +141,7 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -154,7 +154,7 @@ jobs:
           container-registry: ${{ inputs.container-registry }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Build image
         env:

--- a/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
@@ -128,7 +128,7 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-publish-integrasjonspunkt.yml
@@ -168,7 +168,7 @@ jobs:
           trivy-version: ${{ inputs.trivy-version }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # pin@v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # pin@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
+++ b/.github/workflows/ci-docker-build-scan-integrasjonspunkt.yml
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-docker-container-scan.yml
+++ b/.github/workflows/ci-docker-container-scan.yml
@@ -107,7 +107,7 @@ jobs:
           container-registry: "my-local-registry"
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Build image
         env:

--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-maven-build-lib.yml
+++ b/.github/workflows/ci-maven-build-lib.yml
@@ -135,7 +135,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -137,7 +137,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-maven-build.yml
+++ b/.github/workflows/ci-maven-build.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -114,7 +114,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-maven-deploy.yml
+++ b/.github/workflows/ci-maven-deploy.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -125,7 +125,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/ci-maven-install-deploy-lib.yml
+++ b/.github/workflows/ci-maven-install-deploy-lib.yml
@@ -130,7 +130,7 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-pr-checks-image.yml
+++ b/.github/workflows/ci-pr-checks-image.yml
@@ -197,7 +197,7 @@ jobs:
     name: Call Spring Boot container scan
     if: |
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2541-test-workflow-dependabot-version-bumps
     permissions:
       contents: read
     with:

--- a/.github/workflows/ci-pr-checks-lib.yml
+++ b/.github/workflows/ci-pr-checks-lib.yml
@@ -154,7 +154,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-pr-checks-lib.yml
+++ b/.github/workflows/ci-pr-checks-lib.yml
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -223,7 +223,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -295,7 +295,7 @@ jobs:
     if: |
       inputs.enable-image-build == true &&
       inputs.application-type == 'spring-boot'
-    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@main
+    uses: felleslosninger/github-workflows/.github/workflows/ci-spring-boot-container-scan.yml@PF-2541-test-workflow-dependabot-version-bumps
     permissions:
       contents: read
     with:

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -183,7 +183,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -180,7 +180,7 @@ jobs:
           container-registry: ${{ inputs.container-registry }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -127,7 +127,7 @@ jobs:
           image-name: ${{ inputs.image-name }}
           container-registry: "my-local-registry"
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -271,7 +271,7 @@ jobs:
       # Login to GHCR if container-registry starts with ghcr.io
       - name: Login to GitHub Container Registry
         if: contains(inputs.container-registry, 'ghcr.io')
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # pin@v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # pin@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -197,7 +197,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -194,7 +194,7 @@ jobs:
           image-tag: ${{ inputs.image-tag }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -137,7 +137,7 @@ jobs:
           container-registry: "my-local-registry"
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Set up JDK ${{ inputs.java-version }}
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0

--- a/.github/workflows/ci-spring-boot-container-scan.yml
+++ b/.github/workflows/ci-spring-boot-container-scan.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
       - name: Set up JDK ${{ inputs.java-version }}
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # pin@v5.2.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # pin@v5.7.0
         with:
           distribution: "${{ inputs.java-distribution }}"
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
+++ b/.github/workflows/misc-approve-and-merge-dependabot-pr.yml
@@ -70,7 +70,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Fetch update types
         id: update-types

--- a/.github/workflows/misc-publish-dev-docker.yml
+++ b/.github/workflows/misc-publish-dev-docker.yml
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.CR_DEV_SECRET }}
 
       - name: Build and push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # pin@v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # pin@v7.2.0
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/misc-publish-dev-docker.yml
+++ b/.github/workflows/misc-publish-dev-docker.yml
@@ -60,7 +60,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # pin@v4.0.0
 
       - name: Login to crutvikling (Azure container registry)
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # pin@v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # pin@v4.6.0
         with:
           registry: ${{ vars.CR_DEV_URL }}
           username: ${{ secrets.CR_DEV_USERNAME }}

--- a/.github/workflows/misc-publish-dev-docker.yml
+++ b/.github/workflows/misc-publish-dev-docker.yml
@@ -57,7 +57,7 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # pin@v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # pin@v4.0.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # pin@v4.2.0
 
       - name: Login to crutvikling (Azure container registry)
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # pin@v4.6.0

--- a/.github/workflows/misc-publish-dev-docker.yml
+++ b/.github/workflows/misc-publish-dev-docker.yml
@@ -54,7 +54,7 @@ jobs:
       REPOSITORY-NAME: ${{ github.event.repository.name }}
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # pin@v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # pin@v4.1.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # pin@v4.2.0

--- a/.github/workflows/test-k6-build-docker.yml
+++ b/.github/workflows/test-k6-build-docker.yml
@@ -82,7 +82,7 @@ jobs:
           image-name: ${{ inputs.image-name }}
           container-registry: "my-local-registry"
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Copy k6-tests to docker temp
         run: |

--- a/.github/workflows/test-k6-build-publish-docker.yml
+++ b/.github/workflows/test-k6-build-publish-docker.yml
@@ -101,7 +101,7 @@ jobs:
           image-name: ${{ inputs.image-name }}
           container-registry: ${{ secrets.REGISTRY_URL }}
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # pin@v7.0.1
 
       - name: Find and replace image version for ${{ steps.image-metadata.outputs.image-tag }} in version endpoint
         uses: jacobtomlinson/gha-find-replace@f1069b438f125e5395d84d1c6fd3b559a7880cb5 # pin@v3.0.5


### PR DESCRIPTION
Pipeline testing regarding action version bumps. Part of https://digdir.atlassian.net/browse/PF-2541

**actions/checkout** Verified OK (6.0.2 to 7.0.1)
https://github.com/felleslosninger/plattform-test-app/actions/runs/31683837435/job/94395596262#step:3:1

**actions/setup-java Verified OK** (5.2.0 to 5.7.0)
https://github.com/felleslosninger/plattform-test-app/actions/runs/31466761921/job/93701389594

**docker/login-action Verified OK** (4.1.0 to 4.6.0)
https://github.com/felleslosninger/plattform-test-app/actions/runs/31691246267/job/94418844958

**docker/build-push-action Verified OK** (7.1.0 to 7.2.0)
https://github.com/felleslosninger/plattform-test-app/actions/runs/31691246267/job/94418844958

**docker/setup-buildx-action Verified OK** (4.0.0 to 4.2.0)
https://github.com/felleslosninger/plattform-test-app/actions/runs/31691246267/job/94418844958

**docker/setup-qemu-action Verified OK** (4.0.0 to 4.1.0)
https://github.com/felleslosninger/plattform-test-app/actions/runs/31691246267/job/94418844958