### PR TITLE
Oppdatere version-set med --file parameter i ci-spring-boot-build-publish-image.yml

### DIFF
--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -215,7 +215,7 @@ jobs:
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
         run: |
           if [ "$UPDATE_VERSIONS" == "true" ]; then
-            mvn versions:set -B -DnewVersion="$IMAGE_TAG"
+            mvn versions:set -B --file "${APP_PATH}pom.xml" -DnewVersion="$IMAGE_TAG"
             echo "- \`mvn versions\` was executed" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- \`mvn versions\` was not executed" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-spring-boot-build-publish-image.yml
+++ b/.github/workflows/ci-spring-boot-build-publish-image.yml
@@ -213,6 +213,7 @@ jobs:
           GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           UPDATE_VERSIONS: ${{ inputs.update-versions }}
           IMAGE_TAG: ${{ steps.image-metadata.outputs.image-tag }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
           if [ "$UPDATE_VERSIONS" == "true" ]; then
             mvn versions:set -B --file "${APP_PATH}pom.xml" -DnewVersion="$IMAGE_TAG"


### PR DESCRIPTION
Spring boot build image https://github.com/felleslosninger/github-workflows/blob/main/.github/workflows/ci-spring-boot-build-publish-image.yml#L252 tar application-path som input. 

Men version-set tar alltid utgangspunkt i pom.xml på root. Det blir problematisk når vi lager mono-repo. 

---

Usikker på hvorfor dette er ulikt i samme workflow fil, men burde standardisere. Har verifisert kommandoen lokalt. 