### PR TITLE
PF-2538 sh-scan into ci-docker-build-publish-image

### DIFF
--- a/.github/actions/sh-scan/README.md
+++ b/.github/actions/sh-scan/README.md
@@ -1,0 +1,40 @@
+# GitHub Action: Shai-Hulud scan
+
+Author: **Digdir Platform Team**
+
+## Description
+
+Scans for Indicators of Compromise (IOCs) related to the Shai-Hulud supply chain attack in NPM. The action installs dependencies with `--ignore-scripts` to prevent execution of potentially malicious install scripts, then computes SHA256 hashes of known targeted filenames in `node_modules` and compares them against a list of known malicious hashes.
+
+If no `package.json` is found in the application path, the scan is skipped gracefully.
+
+## Prerequisites
+
+- The repository must be checked out before running this action.
+- Node.js and the relevant package manager (`npm`, `yarn`, or `pnpm`) must be available on the runner.
+
+## Inputs
+
+| Input | Description | Required | Default |
+| :---- | :---------- | :------- | :------ |
+| `install_method` | Package manager to use: `npm`, `yarn`, `ci`, or `pnpm` | Yes | - |
+| `application-path` | Path to the application directory containing `package.json` | No | `./` |
+
+## Example usage
+
+```yaml
+- name: Run Shai-Hulud scan
+  uses: felleslosninger/github-workflows/.github/actions/sh-scan@main
+  with:
+    install_method: npm
+    application-path: ./apps/frontend
+```
+
+## How it works
+
+1. Changes directory to `application-path`.
+2. Checks for `package.json` — skips if not found (non-JS project).
+3. Installs dependencies using the specified package manager with `--ignore-scripts`.
+4. Searches `node_modules` for files matching known IOC filenames ( eks. `bundle.js`, `setup.mjs`, `Math_Symbol.js`, `setup_bun.js`, `bun_environment.js`,..).
+5. Computes SHA256 hashes of any matches and compares against known malicious hashes.
+6. Fails the step if any hash matches an IOC.

--- a/.github/actions/sh-scan/action.yml
+++ b/.github/actions/sh-scan/action.yml
@@ -6,6 +6,10 @@ inputs:
   install_method:
     description: "npm | yarn | ci | pnpm"
     required: true
+  application-path:
+    description: "Path to the application directory containing package.json"
+    required: false
+    default: "./"
 
 runs:
   using: composite
@@ -14,9 +18,17 @@ runs:
       shell: bash
       env:
         INSTALL_METHOD: ${{ inputs.install_method }}
+        APP_PATH: ${{ inputs.application-path }}
       run: |
         #!/bin/bash
         set -euo pipefail
+
+        cd "$APP_PATH"
+
+        if [[ ! -f "package.json" ]]; then
+            echo "No package.json found in $APP_PATH — not a JavaScript project, skipping sh-scan."
+            exit 0
+        fi
 
         # Fill these arrays with known IOC from NPM attacks
         SUSPICIOUS_NODE_FILES=(

--- a/.github/actions/sh-scan/action.yml
+++ b/.github/actions/sh-scan/action.yml
@@ -22,12 +22,15 @@ runs:
         SUSPICIOUS_NODE_FILES=(
             "setup_bun.js"
             "bun_environment.js"
+
         )
 
         # Will only compute the hashes of the files in IOC_SHA256_FILES
         # Then check if they match any of the hashes in IOC_SHA256
         IOC_SHA256_FILES=(
             "bundle.js"
+            "setup.msj"
+            "Math_Symbol.js"
         )
 
         IOC_SHA256=(
@@ -35,6 +38,9 @@ runs:
             "b74caeaa75e077c99f7d44f46daaf9796a3be43ecf24f2a1fd381844669da777"
             "dc67467a39b70d1cd4c1f7f7a459b35058163592f4a9e8fb4dffcbba98ef210c"
             "4b2399646573bb737c4969563303d8ee2e9ddbd1b271f1ca9e35ea78062538db"
+            "54dc7ea54a1317cca0e890a2770630cf7fa6c97813e0cb9d2caa93012b350668"
+            "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+            "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
 
         )
 

--- a/.github/actions/sh-scan/action.yml
+++ b/.github/actions/sh-scan/action.yml
@@ -31,28 +31,30 @@ runs:
         fi
 
         # Fill these arrays with known IOC from NPM attacks
-        SUSPICIOUS_NODE_FILES=(
-            "setup_bun.js"
+        IOC_SHA256_FILES=(
+            "bundle.js"
+            "setup.mjs"
+            "Math_Symbol.js"
+            "setup_bun.js"            
             "bun_environment.js"
 
         )
 
-        # Will only compute the hashes of the files in IOC_SHA256_FILES
-        # Then check if they match any of the hashes in IOC_SHA256
-        IOC_SHA256_FILES=(
-            "bundle.js"
-            "setup.msj"
-            "Math_Symbol.js"
-        )
-
         IOC_SHA256=(
-            "46faab8ab153fae6e80e7cca38eab363075bb524edd79e42269217a083628f09"
-            "b74caeaa75e077c99f7d44f46daaf9796a3be43ecf24f2a1fd381844669da777"
-            "dc67467a39b70d1cd4c1f7f7a459b35058163592f4a9e8fb4dffcbba98ef210c"
-            "4b2399646573bb737c4969563303d8ee2e9ddbd1b271f1ca9e35ea78062538db"
-            "54dc7ea54a1317cca0e890a2770630cf7fa6c97813e0cb9d2caa93012b350668"
-            "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
-            "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+            "de0e25a3e6c1e1e5998b306b7141b3dc4c0088da9d7bb47c1c00c91e6e4f85d6" #bundle.js
+            "81d2a004a1bca6ef87a1caf7d0e0b355ad1764238e40ff6d1b1cb77ad4f595c3" #bundle.js
+            "83a650ce44b2a9854802a7fb4c202877815274c129af49e6c2d1d5d5d55c501e" #bundle.js
+            "46faab8ab153fae6e80e7cca38eab363075bb524edd79e42269217a083628f09" #bundle.js
+            "b74caeaa75e077c99f7d44f46daaf9796a3be43ecf24f2a1fd381844669da777" #bundle.js
+            "dc67467a39b70d1cd4c1f7f7a459b35058163592f4a9e8fb4dffcbba98ef210c" #bundle.js
+            "4b2399646573bb737c4969563303d8ee2e9ddbd1b271f1ca9e35ea78062538db" #bundle.js
+            "62ee164b9b306250c1172583f138c9614139264f889fa99614903c12755468d0" #bun_environment.js
+            "f099c5d9ec417d4445a0328ac0ada9cde79fc37410914103ae9c609cbc0ee068" #bun_environment.js
+            "cbb9bc5a8496243e02f3cc080efbe3e4a1430ba0671f2e43a202bf45b05479cd" #bun_environment.js
+            "a3894003ad1d293ba96d77881ccd2071446dc3f65f434669b49b3da92421901a" #setup_bun.js
+            "54dc7ea54a1317cca0e890a2770630cf7fa6c97813e0cb9d2caa93012b350668" #setup.mjs
+            "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb" #setup.mjs
+            "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc" #Math_Symbol.js
 
         )
 
@@ -86,35 +88,6 @@ runs:
         echo "WARNING: No SHA256 tool found (sha256sum/shasum), skipping hashcheck for: $f" >&2
         printf '%s' ""
         return 0
-        }
-
-        function scan_files() {
-            local base_dir="$1"
-
-            [[ -d "$base_dir" ]] || {
-                echo "WARNING: Directory not found (skipping file scanning): $base_dir" >&2
-                return 0
-            }
-
-            local found=0
-            local matches=""
-
-            # Iterates the suspicious nodes files, and craches if any is found.
-            for file in "${SUSPICIOUS_NODE_FILES[@]}"; do
-                matches="$(find "$base_dir" -type f -name "$file" -print 2>/dev/null || true)"
-                if [[ -n "$matches" ]]; then
-                    found=1
-                    echo "FAIL: Found suspicious NPM file: $file"
-                    echo "$matches"
-                fi
-            done
-
-            if [[ "$found" -eq 1 ]]; then
-                return 1
-            fi
-
-            echo "OK: No suspicious NPM files found in $base_dir"
-            return 0
         }
 
         function scan_for_hashes() {
@@ -168,22 +141,18 @@ runs:
 
         if [[ "$INSTALL_METHOD" == "npm" ]]; then
             npm install --ignore-scripts
-            scan_files "$NODE_MODULES_DIR"
             scan_for_hashes "$NODE_MODULES_DIR"
 
         elif [[ "$INSTALL_METHOD" == "yarn" ]]; then
             yarn install --frozen-lockfile --ignore-scripts
-            scan_files "$NODE_MODULES_DIR"
             scan_for_hashes "$NODE_MODULES_DIR"
 
         elif [[ "$INSTALL_METHOD" == "ci" ]]; then
             npm ci --ignore-scripts
-            scan_files "$NODE_MODULES_DIR"
             scan_for_hashes "$NODE_MODULES_DIR"
 
         elif [[ "$INSTALL_METHOD" == "pnpm" ]]; then
             pnpm install --frozen-lockfile --ignore-scripts
-            scan_files "$NODE_MODULES_DIR"
             scan_for_hashes "$NODE_MODULES_DIR"
 
         else

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -116,6 +116,16 @@ on:
         type: string
         required: false
         default: ''
+      sh-scan:
+        description: Run Shai-Hulud malicious files scan on node_modules
+        type: boolean
+        required: false
+        default: false
+      sh-scan-install-method:
+        description: Install method for sh-scan (npm | yarn | ci | pnpm)
+        type: string
+        required: false
+        default: 'npm'
 
     outputs:
       image-version:
@@ -155,6 +165,13 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
+
+      - name: Run Shai-Hulud scan
+        if: inputs.sh-scan == true
+        uses: felleslosninger/github-workflows/.github/actions/sh-scan@main
+        with:
+          install_method: ${{ inputs.sh-scan-install-method }}
+          application-path: ${{ inputs.application-path }}
 
       - name: Build image
         env:

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -120,7 +120,7 @@ on:
         description: Run Shai-Hulud malicious files scan on node_modules
         type: boolean
         required: false
-        default: false
+        default: true
       sh-scan-install-method:
         description: Install method for sh-scan (npm | yarn | ci | pnpm)
         type: string

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run Shai-Hulud scan
         if: inputs.sh-scan == true
-        uses: felleslosninger/github-workflows/.github/actions/sh-scan@main
+        uses: felleslosninger/github-workflows/.github/actions/sh-scan@PF-2538-sh-scan-update
         with:
           install_method: ${{ inputs.sh-scan-install-method }}
           application-path: ${{ inputs.application-path }}

--- a/.github/workflows/ci-docker-build-publish-image.yml
+++ b/.github/workflows/ci-docker-build-publish-image.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run Shai-Hulud scan
         if: inputs.sh-scan == true
-        uses: felleslosninger/github-workflows/.github/actions/sh-scan@PF-2538-sh-scan-update
+        uses: felleslosninger/github-workflows/.github/actions/sh-scan@main
         with:
           install_method: ${{ inputs.sh-scan-install-method }}
           application-path: ${{ inputs.application-path }}


### PR DESCRIPTION
**Jira task**: https://digdir.atlassian.net/jira/for-you?tab=assigned&selectedIssue=PF-2538 

**Why**: The sh-scan composite action fails the build of a image if it detects any IOCs related to the Shai-hulud supply chain attack. This PR adds this acton to run in the golden path workflow ci-docker-build-image, and include the possibility to toggle it off. The PR also adds some new Shai-hulud IOCs to the action and does some cleanup. 

**Testing**: 

- Running the action with ci-docker-build-image, where the image is a non-node project: https://github.com/felleslosninger/plattform-test-app/actions/runs/31367407467/job/93388694839. As intended, it skips the shai-hulud scanning step, since it does not find a package.json file. 

- Running the action directly in a node project: https://github.com/felleslosninger/backstage/actions/runs/31691755846/job/94420414190. As intended the shai-hulud scanning step runs, but does not fail the pipeline since it does not find any IOCs in node_modules. 