### PR TITLE
PF-2552 Add docker input to proxy workflow

### DIFF
--- a/.github/workflows/ci-build-publish-image.yml
+++ b/.github/workflows/ci-build-publish-image.yml
@@ -150,6 +150,11 @@ on:
         type: string
         required: false
         default: ''
+      docker-build-context:
+        description: Docker build context directory (resolves COPY/ADD paths). Defaults to the repository root.
+        default: "."
+        required: false
+        type: string
 
     outputs:
       image-version:
@@ -289,4 +294,5 @@ jobs:
       trivy-os-ignore-unfixed: ${{ inputs.trivy-os-ignore-unfixed }}
       trivy-os-severity: ${{ inputs.trivy-os-severity }}
       trivy-version: ${{ inputs.trivy-version }}
+      docker-build-context: ${{ inputs.docker-build-context }}
     secrets: inherit


### PR DESCRIPTION
PF-2474 added the docker-build-context input to ci-docker-build-publish-image.yml to fix failing builds but forgot to pass it through the proxy workflow ci-build-publish-image.yml. This PR closes that gap and add the docker-build-context input.