### PR TITLE
Bump: support libraries in a monorepo subfolder

### DIFF
--- a/.github/workflows/ci-build-publish-lib.yml
+++ b/.github/workflows/ci-build-publish-lib.yml
@@ -12,6 +12,11 @@
 #   private GitHub Packages repositories) by reading dependencies with the
 #   'GH_PACKAGES_READ_USER' / 'GH_PACKAGES_READ_PAT' secrets.
 #
+#   The library is assumed to live at the repository root. Set 'application-path'
+#   to release a library that lives in a subfolder of a monorepo; every Maven
+#   invocation is then pointed at '<application-path>pom.xml', which becomes the
+#   reactor root that 'module-name' is resolved against.
+#
 #   'mvn clean install' always runs BEFORE the Trivy filesystem scan. This is
 #   required so that Maven resolves and builds the full dependency tree
 #   (including internal and transitive dependencies) locally first; the Trivy
@@ -54,6 +59,11 @@ permissions: {}
 on:
   workflow_call:
     inputs:
+      application-path:
+        description: "Path to the library to build and publish, relative to the repository root. Maven is pointed at '<application-path>pom.xml', which becomes the reactor root, so this is what makes a library in a monorepo subfolder releasable. Must end with a trailing slash (e.g. 'log-event-lib/')"
+        default: "./"
+        required: false
+        type: string
       cache-path:
         description: Path to cache dependencies, relative to the repository root
         default: "**/pom.xml"
@@ -84,7 +94,7 @@ on:
         required: false
         type: string
       module-name:
-        description: Directory path of the Maven module to build and publish, relative to the reactor root (e.g. 'payment/api'), for multi-module reactor projects. Must be the module directory path, NOT the Maven coordinate form (`:artifactId` or `groupId:artifactId`), because the Trivy scan and SBOM steps derive filesystem paths from it. When set, the build is scoped with `-pl <module-name> -am` so the module and its upstream reactor dependencies are built (in order) and only this module is deployed. When empty, the full reactor is built and deployed from the repository root.
+        description: Directory path of the Maven module to build and publish, relative to the reactor root (e.g. 'payment/api'), for multi-module reactor projects. The reactor root is the repository root, or 'application-path' when that is set. Must be the module directory path, NOT the Maven coordinate form (`:artifactId` or `groupId:artifactId`), because the Trivy scan and SBOM steps derive filesystem paths from it. When set, the build is scoped with `-pl <module-name> -am` so the module and its upstream reactor dependencies are built (in order) and only this module is deployed. When empty, the full reactor is built and deployed from the reactor root.
         required: false
         type: string
       package-version:
@@ -156,9 +166,10 @@ jobs:
           GH_PACKAGES_READ_USER: ${{ secrets.GH_PACKAGES_READ_USER }}
           GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           PACKAGE_VERSION: ${{ inputs.package-version }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
           if [ -n "$PACKAGE_VERSION" ]; then
-            mvn versions:set -B -DnewVersion="$PACKAGE_VERSION"
+            mvn versions:set -B --file "${APP_PATH}pom.xml" -DnewVersion="$PACKAGE_VERSION"
             echo "- \`mvn versions:set\` was executed" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- \`mvn versions:set\` was not executed" >> "$GITHUB_STEP_SUMMARY"
@@ -170,8 +181,12 @@ jobs:
           GH_PACKAGES_READ_PAT: ${{ secrets.GH_PACKAGES_READ_PAT }}
           PROFILE: ${{ inputs.maven-profile }}
           MODULE_NAME: ${{ inputs.module-name }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
-          MAVEN_ARGS=("-B" "clean" "install" "--update-snapshots")
+          # Point Maven at the library's own pom rather than the working
+          # directory. This pom is the reactor root, so '-pl' below stays
+          # relative to it. Defaults to './pom.xml'.
+          MAVEN_ARGS=("-B" "clean" "install" "--update-snapshots" "--file" "${APP_PATH}pom.xml")
 
           if [ -n "$MODULE_NAME" ]; then
             # Multi-module: build only this module and its upstream reactor
@@ -192,9 +207,12 @@ jobs:
         with:
           scan-type: "fs"
           # Scope the scan to the built module (its upstream reactor deps are
-          # resolved from the warm ~/.m2 via the module pom); repo root when
-          # 'module-name' is unset.
-          application-path: ${{ inputs.module-name || './' }}
+          # resolved from the warm ~/.m2 via the module pom); the reactor root
+          # when 'module-name' is unset. 'module-name' is relative to the
+          # reactor root, so it is prefixed with 'application-path' to get a
+          # path from the repository root. Both inputs default such that this
+          # evaluates to './'.
+          application-path: ${{ inputs.application-path }}${{ inputs.module-name }}
           library-disable-scan: ${{ inputs.trivy-library-disable-scan }}
           library-ignore-unfixed: ${{ inputs.trivy-library-ignore-unfixed }}
           library-severity: ${{ inputs.trivy-library-severity }}
@@ -215,8 +233,9 @@ jobs:
           PROFILE: ${{ inputs.maven-profile }}
           DEPLOYMENT_REPO: ${{ inputs.deployment-repository }}
           MODULE_NAME: ${{ inputs.module-name }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
-          MAVEN_ARGS=("-B" "deploy" "-DskipTests")
+          MAVEN_ARGS=("-B" "deploy" "-DskipTests" "--file" "${APP_PATH}pom.xml")
 
           if [ -n "$MODULE_NAME" ]; then
             # Multi-module: deploy only the selected module, from the reactor
@@ -250,11 +269,20 @@ jobs:
           SBOM_PATH: ${{ inputs.sbom-path }}
           REPO_NAME: ${{ github.event.repository.name }}
           MODULE_NAME: ${{ inputs.module-name }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
           # Default to the selected module directory (so multi-module SBOMs keep
-          # a per-module artifact id), then the repository root, if 'sbom-path'
-          # is empty
-          RAW_PATH="${SBOM_PATH:-${MODULE_NAME:-.}}"
+          # a per-module artifact id), then the reactor root, if 'sbom-path' is
+          # empty. 'module-name' is relative to the reactor root, so it is
+          # prefixed with 'application-path' to get a path from the repository
+          # root; 'sbom-path' is already relative to the repository root.
+          if [ -n "$SBOM_PATH" ]; then
+            RAW_PATH="$SBOM_PATH"
+          elif [ -n "$MODULE_NAME" ]; then
+            RAW_PATH="${APP_PATH}${MODULE_NAME}"
+          else
+            RAW_PATH="${APP_PATH}"
+          fi
           CLEAN_PATH=$(echo "$RAW_PATH" | sed 's/\/target$//' | sed 's/^\.\///' | sed 's/\/$//')
 
           # Resolve the Artifact ID

--- a/.github/workflows/ci-pr-checks-lib.yml
+++ b/.github/workflows/ci-pr-checks-lib.yml
@@ -8,8 +8,10 @@
 #
 #   Flow:
 #     1. Verifies PR title
-#     2. Builds and tests from root pom with mvn lifecycle chosen in
-#        inputs (default: install).
+#     2. Builds and tests with the mvn lifecycle chosen in inputs
+#        (default: install). Builds from the repository root pom by default;
+#        set 'application-path' to build a library that lives in a subfolder
+#        of a monorepo instead.
 #     3. Scans with Trivy FS scan to fail fast on library vulnerabilities
 #     4. Uploads build artifact (optional)
 #     5. Auto-merges Dependabot PRs (optional)
@@ -47,7 +49,7 @@ on:
         required: false
         type: string
       application-path:
-        description: Path to the directory to scan with Trivy (also used to locate a module-local .trivyignore), relative to the repository root
+        description: "Path to the library to build, relative to the repository root. Maven is pointed at '<application-path>pom.xml', so this is what makes a library in a monorepo subfolder buildable. Must end with a trailing slash (e.g. 'log-event-lib/'). Also used as the Trivy scan target and to locate a module-local .trivyignore"
         default: "./"
         required: false
         type: string
@@ -171,6 +173,7 @@ jobs:
           LIFECYCLE: ${{ inputs.maven-lifecycle }}
           MAVEN_CLEAN: ${{ inputs.maven-clean }}
           UPDATE_SNAPSHOTS: ${{ inputs.maven-update-snapshots }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
           case "$LIFECYCLE" in
             test|package|verify|install)
@@ -193,6 +196,11 @@ jobs:
           if [ "$UPDATE_SNAPSHOTS" == "true" ]; then
             ARGS+=("--update-snapshots")
           fi
+
+          # Point Maven at the library's own pom rather than the working
+          # directory, so a library in a monorepo subfolder builds its own
+          # reactor instead of the repository root. Defaults to './pom.xml'.
+          ARGS+=("--file" "${APP_PATH}pom.xml")
 
           # Execute the Maven command
           mvn "${ARGS[@]}"

--- a/docs/pull-request-lib.md
+++ b/docs/pull-request-lib.md
@@ -134,11 +134,30 @@ will always run.
 > to `false` to save time. Only enable `maven-update-snapshots` if your PR
 > depends on newly published internal snapshots.
 
-##### Trivy
+##### Application path
 
 | Override | Type | Workflow default |
 | -------- | ---- | ---------------- |
 | `application-path` | `string` | `./` |
+
+> [!NOTE]
+> **Path formatting:** The path is relative to the repository root. If you
+> override this value, you **must include a trailing slash** (e.g.,
+> `log-event-lib/`). The underlying build scripts concatenate this directly with
+> filenames (evaluating to `${APP_PATH}pom.xml`), and the build will fail if the
+> slash is missing.
+
+> [!TIP]
+> Override this to build a library that lives in a subfolder of a monorepo.
+> Maven is pointed at `<application-path>pom.xml`, so the library builds its own
+> reactor rather than the repository root. It is also the Trivy scan target and
+> where a module-local `.trivyignore` is looked up. Set `cache-path` to the same
+> pom to keep the dependency cache scoped to that library.
+
+##### Trivy
+
+| Override | Type | Workflow default |
+| -------- | ---- | ---------------- |
 | `trivy-library-disable-scan` | `boolean` | `false` |
 | `trivy-library-ignore-unfixed` | `boolean` | `true` |
 | `trivy-library-severity` | `string` | `HIGH,CRITICAL` |

--- a/docs/release-lib.md
+++ b/docs/release-lib.md
@@ -105,6 +105,25 @@ will always run.
 > When this is overridden, `mvn versions:set` is run dynamically during the
 > build using the overridden package version before packaging the artifact.
 
+##### Application path
+
+| Override | Type | Workflow default |
+| -------- | ---- | ---------------- |
+| `application-path` | `string` | `./` |
+
+> [!NOTE]
+> **Path formatting:** The path is relative to the repository root. If you
+> override this value, you **must include a trailing slash** (e.g.,
+> `log-event-lib/`). The underlying build scripts concatenate this directly with
+> filenames (evaluating to `${APP_PATH}pom.xml`), and the build will fail if the
+> slash is missing.
+
+> [!TIP]
+> Override this to release a library that lives in a subfolder of a monorepo.
+> Every Maven invocation is pointed at `<application-path>pom.xml`, which becomes
+> the reactor root. See the [**Examples**](#libraries-in-a-monorepo-subfolder)
+> section below.
+
 ##### Maven
 
 | Override | Type | Workflow default |
@@ -119,6 +138,10 @@ will always run.
 > (e.g., `payment/api`), NOT the Maven coordinate form (`:artifactId` or
 > `groupId:artifactId`). The Trivy scanner and SBOM generators derive their
 > filesystem target paths directly from this input.
+>
+> The reactor root is the repository root, or `application-path` when that is
+> set. With `application-path: libs/payments/` and `module-name: api`, the
+> module built and published is `libs/payments/api`.
 
 ##### Trivy
 
@@ -143,7 +166,9 @@ will always run.
 > [!NOTE]
 >
 > - Leaving `sbom-path` empty will default to the `module-name` if provided, or
->   the repository root if not.
+>   the reactor root if not. When `application-path` is set, it is prefixed to
+>   `module-name` (which is relative to the reactor root); `sbom-path`, if you
+>   set it, is always relative to the repository root.
 >
 > - Leaving `sbom-artifact-id` empty will default to the clean `sbom-path`
 >   folder name (for multi-module projects), or the GitHub repository name (for
@@ -187,3 +212,40 @@ jobs:
       module-name: ${{ matrix.module }}
     secrets: inherit
 ```
+
+### Libraries in a monorepo subfolder
+
+When the library does not live at the repository root, set `application-path` to
+its directory. Every Maven invocation is pointed at `<application-path>pom.xml`,
+so the library builds and publishes its own reactor rather than the repository
+root.
+
+```yaml
+name: Release log-event-lib
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  create-release:
+    uses: felleslosninger/github-workflows/.github/workflows/ci-build-publish-lib.yml@main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      # Trailing slash is required
+      application-path: log-event-lib/
+      # Keep the dependency cache scoped to this library
+      cache-path: log-event-lib/pom.xml
+      package-version: ${{ github.event.release.tag_name }}
+      deployment-repository: ${{ github.repository }}
+    secrets: inherit
+```
+
+> [!CAUTION]
+> `on: release` is repository-global. In a monorepo, every GitHub release fires
+> every workflow that listens for it, so this is only safe while the repository
+> publishes a single Maven artifact. If it publishes more than one, gate the job
+> on the release tag.


### PR DESCRIPTION
`ci-pr-checks-lib.yml `og `ci-build-publish-lib.yml` kjørte tidligere Maven fra rotmappen. Biblioteker i en undermappe i et monorepo kunne derfor ikke bygges eller publiseres, siden Maven forventet en aggregator-POM i roten. module-name løste ikke dette, fordi -pl <module> -am fortsatt tok utgangspunkt i rotmappen.

Begge workflowene bruker nå <application-path>pom.xml, slik container-workflowene allerede gjør:

ci-pr-checks-lib.yml: application-path brukes nå også i Maven-steget.

ci-build-publish-lib.yml: legger til application-path for versjonssetting, installasjon og publisering.

application-path er nå reactor-roten, mens module-name fortsatt er relativ til denne. Trivy- og SBOM-stier kombinerer begge verdiene ved behov, mens sbom-path fortsatt er relativ til repository-roten.

Standardverdien er ./, så eksisterende bruk påvirkes ikke.