### PR TITLE
Bugfix: Make sh-scan work with pnpm

### DIFF
--- a/.github/actions/sh-scan/action.yml
+++ b/.github/actions/sh-scan/action.yml
@@ -144,6 +144,7 @@ runs:
             scan_for_hashes "$NODE_MODULES_DIR"
 
         elif [[ "$INSTALL_METHOD" == "yarn" ]]; then
+            corepack enable yarn
             yarn install --frozen-lockfile --ignore-scripts
             scan_for_hashes "$NODE_MODULES_DIR"
 
@@ -152,6 +153,7 @@ runs:
             scan_for_hashes "$NODE_MODULES_DIR"
 
         elif [[ "$INSTALL_METHOD" == "pnpm" ]]; then
+            corepack enable pnpm
             pnpm install --frozen-lockfile --ignore-scripts
             scan_for_hashes "$NODE_MODULES_DIR"
 


### PR DESCRIPTION
Why: the sh-scan composite action does not work with pnpm override, because the runner does not have access to the pnpm command: https://github.com/felleslosninger/kut-kundeportal/actions/runs/32348698871/job/96362935502 

This PR fixes this by enabeling the pnpm command via corepack. 
