### PR TITLE
Fix Quarkus buildpack build to respect application-path

### DIFF
--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -98,7 +98,7 @@ on:
         type: boolean
         default: false
       application-path:
-        description: Path to the application directory to scan with Trivy, relative to the repository root
+        description: Path to the application directory, relative to the repository root. Used as the buildpack build context and to locate a module-local .trivyignore
         default: "./"
         required: false
         type: string
@@ -232,9 +232,10 @@ jobs:
           IMAGE_PACK: ${{ inputs.image-pack }}
           IMAGE_PACK_TAG: ${{ inputs.image-pack-tag }}
           JAVA_VERSION: ${{ inputs.java-version }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
           pack build "$IMAGE_NAME:$IMAGE_TAG" \
-            --path . \
+            --path "$APP_PATH" \
             --buildpack docker://paketobuildpacks/quarkus \
             --buildpack docker://paketobuildpacks/java-native-image \
             --builder "paketobuildpacks/$IMAGE_PACK:$IMAGE_PACK_TAG" \
@@ -258,9 +259,10 @@ jobs:
           IMAGE_PACK: ${{ inputs.image-pack }}
           IMAGE_PACK_TAG: ${{ inputs.image-pack-tag }}
           JAVA_VERSION: ${{ inputs.java-version }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
           pack build "$IMAGE_NAME:$IMAGE_TAG" \
-            --path . \
+            --path "$APP_PATH" \
             --buildpack docker://paketobuildpacks/quarkus \
             --buildpack docker://paketobuildpacks/java \
             --builder "paketobuildpacks/$IMAGE_PACK:$IMAGE_PACK_TAG" \

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -73,7 +73,7 @@ on:
         type: boolean
         default: false
       application-path:
-        description: Path to the application directory to scan with Trivy, relative to the repository root
+        description: Path to the application directory, relative to the repository root. Used as the buildpack build context and to locate a module-local .trivyignore
         default: "./"
         required: false
         type: string
@@ -165,9 +165,10 @@ jobs:
           IMAGE_PACK: ${{ inputs.image-pack }}
           IMAGE_PACK_TAG: ${{ inputs.image-pack-tag }}
           JAVA_VERSION: ${{ inputs.java-version }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
           pack build "$IMAGE_NAME:$IMAGE_TAG" \
-            --path . \
+            --path "$APP_PATH" \
             --buildpack docker://paketobuildpacks/quarkus \
             --buildpack docker://paketobuildpacks/java-native-image \
             --builder "paketobuildpacks/$IMAGE_PACK:$IMAGE_PACK_TAG" \
@@ -190,9 +191,10 @@ jobs:
           IMAGE_PACK: ${{ inputs.image-pack }}
           IMAGE_PACK_TAG: ${{ inputs.image-pack-tag }}
           JAVA_VERSION: ${{ inputs.java-version }}
+          APP_PATH: ${{ inputs.application-path }}
         run: |
           pack build "$IMAGE_NAME:$IMAGE_TAG" \
-            --path . \
+            --path "$APP_PATH" \
             --buildpack docker://paketobuildpacks/quarkus \
             --buildpack docker://paketobuildpacks/java \
             --builder "paketobuildpacks/$IMAGE_PACK:$IMAGE_PACK_TAG" \


### PR DESCRIPTION
## Problem

`ci-quarkus-container-scan.yml` and `ci-quarkus-build-publish-image.yml` both hardcode `pack build --path .` and `--env BP_MAVEN_POM_FILE="./pom.xml"`. `application-path` is threaded into the Trivy scan step but never into the actual buildpack build.

This is invisible for single-app repos, where `application-path` defaults to `./` — the same thing as the hardcoded `.`. It breaks the moment a Quarkus app lives in a monorepo subdirectory: `pack build` runs from the repository root, and its Maven buildpack detector picks up whichever `pom.xml` it finds first — not necessarily the Quarkus app's own.

## How it was found

Setting up `kut-operational-status` (Spring Boot `operational-status-service` + Quarkus `operational-status-admin` in one repo). The admin's PR check failed buildpack detection:

```
[detector] fail: paketo-buildpacks/quarkus@0.9.2
[detector] pass: paketo-buildpacks/maven@6.24.1
[detector] pass: paketo-buildpacks/spring-boot@5.36.6
[detector] ERROR: No buildpack groups passed detection.
```

The Spring Boot buildpack passing detection for a Quarkus app was the tell — `pack` was building against `operational-status-service`'s `pom.xml`, not `operational-status-admin`'s. Confirmed by reading the source: `--path .` and `BP_MAVEN_POM_FILE="./pom.xml"` are never overridden by `application-path`.

## Fix

Pass `application-path` into `pack build --path` in all four build steps (native/JVM × container-scan/build-publish-image). `BP_MAVEN_POM_FILE` stays `./pom.xml`, now correctly relative to the app-path root instead of the repo root.

Backward compatible: `application-path` defaults to `"./"`, so `--path "./"` behaves identically to the current `--path .` for existing single-app callers.

## Verification

- YAML validated (`ruby -ryaml`).
- Not yet verified against a live monorepo run — `kut-operational-status`'s `operational-status-admin.yml` already passes `application-path: operational-status-admin/` correctly (it was the caller-side config that was already right), so once this merges the next PR/push there should build the correct app without any change on our end.