### PR TITLE
Fix native-sources artifact glob for Quarkus native image builds

### DIFF
--- a/.github/workflows/ci-quarkus-build-publish-image.yml
+++ b/.github/workflows/ci-quarkus-build-publish-image.yml
@@ -242,6 +242,7 @@ jobs:
             --volume "${HOME}/.m2:/home/cnb/.m2:rw" \
             --env BP_JVM_VERSION="$JAVA_VERSION" \
             --env BP_MAVEN_POM_FILE="./pom.xml" \
+            --env BP_MAVEN_BUILT_ARTIFACT="target/*-native-image-source-jar/*-runner.jar" \
             --env BP_NATIVE_IMAGE="true" \
             --env LANG="C.UTF-8" \
             --env GH_PACKAGES_READ_USER="$GH_PACKAGES_READ_USER" \

--- a/.github/workflows/ci-quarkus-container-scan.yml
+++ b/.github/workflows/ci-quarkus-container-scan.yml
@@ -175,6 +175,7 @@ jobs:
             --volume "${HOME}/.m2:/home/cnb/.m2:rw" \
             --env BP_JVM_VERSION="$JAVA_VERSION" \
             --env BP_MAVEN_POM_FILE="./pom.xml" \
+            --env BP_MAVEN_BUILT_ARTIFACT="target/*-native-image-source-jar/*-runner.jar" \
             --env BP_NATIVE_IMAGE="true" \
             --env LANG="C.UTF-8" \
             --env GH_PACKAGES_READ_USER="$GH_PACKAGES_READ_USER" \


### PR DESCRIPTION
## Problem

`ci-quarkus-build-publish-image.yml` and `ci-quarkus-container-scan.yml`'s native build steps (`if: inputs.native == true`) don't set `BP_MAVEN_BUILT_ARTIFACT`, so the Paketo Maven buildpack falls back to its own default: `target/native-sources/*`.

That default doesn't match where Quarkus actually writes the native-sources runner jar when packaging with `-Dquarkus.package.type=native-sources`:

```
target/<artifactId>-<version>-native-image-source-jar/<artifactId>-<version>-runner.jar
```

`target/native-sources/` only holds the native-image build args/sources file, not the jar. With the wrong glob, the Maven buildpack's artifact layer never picks up the runner jar, so the downstream `java-native-image` buildpack fails:

```
Error: Main entry point class '/workspace/<name>-runner.jar' neither found on
classpath: '/layers/paketo-buildpacks_native-image/native-image' nor
modulepath: '/layers/paketo-buildpacks_bellsoft-liberica/native-image-svm/lib/svm/library-support.jar'.
```

## How it was found

Continuation of #485. Once that fix let `pack build` correctly reach `operational-status-admin`'s own `pom.xml`, the native build got far enough to hit this — a separate, pre-existing bug unrelated to monorepo path-scoping. It would affect any Quarkus app anywhere using `native: true`, single-app repo or not.

## Fix

Explicitly set `BP_MAVEN_BUILT_ARTIFACT="target/*-native-image-source-jar/*-runner.jar"` on both native build steps, matching Quarkus's actual output location instead of relying on the buildpack's incorrect default.

## Verification

- YAML validated (`ruby -ryaml`).
- Reproduced the failure locally against `operational-status-admin` with the exact Maven command the buildpack runs (`mvn --batch-mode --file ./pom.xml package -DskipTests=true -Dmaven.javadoc.skip=true -Dquarkus.package.type=native-sources`), confirming the jar lands at `target/operational-status-admin-DEV-SNAPSHOT-native-image-source-jar/operational-status-admin-DEV-SNAPSHOT-runner.jar`.
- Not yet verified against a live CI run — will confirm once this merges and `kut-operational-status`'s admin PR checks re-run.

## Blast radius / scope check

`BP_MAVEN_BUILT_ARTIFACT` is never set by this repo's workflows today — the broken glob is purely the Paketo buildpack's own default, applied identically to every `native: true` caller. So this isn't monorepo- or app-specific; it should affect (and this fix should help) every current and future consumer of `native: true` on these two files.

Checked what I could see from here:
- [`idporten-authorization-demo-client`](https://github.com/felleslosninger/idporten-authorization-demo-client)'s `call-buildimage.yml` also calls `ci-quarkus-build-publish-image.yml` with `native: true`, default `application-path`. Its pom.xml has no custom `<finalName>` or `quarkus.package.output-directory` — same layout as `operational-status-admin`, so it should hit the same bug today and be fixed the same way.
- `operational-status-admin` — verified directly (see Verification above).

**Caveat I can't rule out from here:** the glob assumes the native-sources jar stays under `target/`. If a caller sets `quarkus.package.output-directory` to relocate it, this glob won't match — there's a [known Quarkus issue](https://github.com/quarkusio/quarkus/issues/33450) about that setting interacting badly with native builds already. GitHub code search doesn't give me full visibility into every private repo in the org, so if anyone reviewing has visibility into other `native: true` consumers, worth a quick check for that property before merging.
